### PR TITLE
Separate Telegram messages for text, tool use, and thinking

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -1,14 +1,21 @@
 import { spawn } from "bun"
 
+type ContentBlockStart =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "thinking"; thinking: string }
+
+type ContentBlockDelta =
+  | { type: "text_delta"; text: string }
+  | { type: "input_json_delta"; partial_json: string }
+  | { type: "thinking_delta"; thinking: string }
+  | { type: "signature_delta"; signature: string }
+
 type StreamEvent =
   | { type: "system"; subtype: "init"; session_id: string }
-  | {
-      type: "stream_event"
-      event: {
-        type: "content_block_delta"
-        delta: { type: "text_delta"; text: string }
-      }
-    }
+  | { type: "stream_event"; event: { type: "content_block_start"; index: number; content_block: ContentBlockStart } }
+  | { type: "stream_event"; event: { type: "content_block_delta"; index: number; delta: ContentBlockDelta } }
+  | { type: "stream_event"; event: { type: "content_block_stop"; index: number } }
   | { type: "stream_event"; event: { type: string } }
   | {
       type: "assistant"
@@ -28,16 +35,50 @@ type StreamEvent =
 
 export type ClaudeEvent =
   | { kind: "text_delta"; text: string }
-  | { kind: "turn_boundary" }
+  | { kind: "tool_use"; name: string; input: string }
+  | { kind: "thinking_start" }
+  | { kind: "thinking_done"; durationMs: number }
   | { kind: "result"; text: string; sessionId: string; cost: number; durationMs: number; turns: number }
   | { kind: "error"; message: string }
 
 const userProcesses = new Map<number, AbortController>()
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000
 
-/** Parse stream-json lines and yield ClaudeEvents */
+/** Format tool input into a short description */
+function formatToolInput(name: string, input: Record<string, unknown>) {
+  switch (name) {
+    case "Read":
+      return input.file_path ? String(input.file_path) : ""
+    case "Write":
+      return input.file_path ? String(input.file_path) : ""
+    case "Edit":
+      return input.file_path ? String(input.file_path) : ""
+    case "Bash": {
+      const cmd = input.command ? String(input.command) : ""
+      return cmd.length > 80 ? cmd.slice(0, 77) + "..." : cmd
+    }
+    case "Glob":
+      return input.pattern ? String(input.pattern) : ""
+    case "Grep":
+      return input.pattern ? String(input.pattern) : ""
+    case "WebFetch":
+      return input.url ? String(input.url) : ""
+    case "WebSearch":
+      return input.query ? String(input.query) : ""
+    case "Task":
+      return input.description ? String(input.description) : ""
+    default:
+      return ""
+  }
+}
+
+/** Create a stateful stream-json parser */
 function createStreamParser() {
-  let hasSeenText = false
+  let hasEmittedContent = false
+  let currentBlockType: "text" | "tool_use" | "thinking" | null = null
+  let currentToolName = ""
+  let toolInputJson = ""
+  let thinkingStartTime = 0
 
   return function* parseStreamLines(lines: string[]): Generator<ClaudeEvent> {
     for (const line of lines) {
@@ -51,16 +92,54 @@ function createStreamParser() {
         continue
       }
 
-      if (parsed.type === "assistant" && hasSeenText) {
-        yield { kind: "turn_boundary" }
+      if (
+        parsed.type === "stream_event" &&
+        parsed.event.type === "content_block_start" &&
+        "content_block" in parsed.event
+      ) {
+        const block = parsed.event.content_block
+        if (block.type === "text") {
+          currentBlockType = "text"
+        } else if (block.type === "tool_use") {
+          currentBlockType = "tool_use"
+          currentToolName = block.name
+          toolInputJson = ""
+        } else if (block.type === "thinking") {
+          currentBlockType = "thinking"
+          thinkingStartTime = Date.now()
+          hasEmittedContent = true
+          yield { kind: "thinking_start" }
+        }
       } else if (
         parsed.type === "stream_event" &&
         parsed.event.type === "content_block_delta" &&
-        "delta" in parsed.event &&
-        parsed.event.delta.type === "text_delta"
+        "delta" in parsed.event
       ) {
-        hasSeenText = true
-        yield { kind: "text_delta", text: parsed.event.delta.text }
+        const delta = parsed.event.delta
+        if (delta.type === "text_delta" && currentBlockType === "text") {
+          hasEmittedContent = true
+          yield { kind: "text_delta", text: delta.text }
+        } else if (delta.type === "input_json_delta" && currentBlockType === "tool_use") {
+          toolInputJson += delta.partial_json
+        }
+        // thinking_delta and signature_delta: ignored (we just show "Thinking...")
+      } else if (
+        parsed.type === "stream_event" &&
+        parsed.event.type === "content_block_stop"
+      ) {
+        if (currentBlockType === "tool_use") {
+          let input: Record<string, unknown> = {}
+          try {
+            input = JSON.parse(toolInputJson)
+          } catch {}
+          const shortInput = formatToolInput(currentToolName, input)
+          hasEmittedContent = true
+          yield { kind: "tool_use", name: currentToolName, input: shortInput }
+        } else if (currentBlockType === "thinking") {
+          const elapsed = Date.now() - thinkingStartTime
+          yield { kind: "thinking_done", durationMs: elapsed }
+        }
+        currentBlockType = null
       } else if (parsed.type === "result") {
         yield {
           kind: "result",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -45,7 +45,7 @@ function markdownToTelegramHtml(md: string) {
   return text
 }
 
-/** Try sending with HTML, fall back to plain text */
+/** Try editing with HTML, fall back to plain text */
 async function safeEditMessage(ctx: Context, chatId: number, messageId: number, text: string, rawText?: string) {
   const displayText = text || "..."
   try {
@@ -66,21 +66,39 @@ type StreamResult = {
   turns?: number
 }
 
-/** Stream Claude events into progressively-edited Telegram messages */
+type MessageMode = "text" | "tools" | "thinking" | "none"
+
+/** Stream Claude events into separate Telegram messages by type */
 export async function streamToTelegram(
   ctx: Context,
   events: AsyncGenerator<ClaudeEvent>,
   projectName: string
 ): Promise<StreamResult> {
   const chatId = ctx.chat!.id
-  const sent = await ctx.reply("...")
-  let messageId = sent.message_id
+  const result: StreamResult = {}
+
+  let mode: MessageMode = "none"
+  let messageId = 0
   let accumulated = ""
   let lastEditTime = 0
   let pendingEdit = false
-  const result: StreamResult = {}
+  let toolLines: string[] = []
+  let lastTextMessageId = 0
 
-  const doEdit = async (final = false) => {
+  /** Send a new Telegram message and track its ID */
+  const sendNew = async (text: string, parseMode?: "HTML") => {
+    const opts = parseMode ? { parse_mode: parseMode as const } : {}
+    const sent = await ctx.api.sendMessage(chatId, text, opts)
+    messageId = sent.message_id
+    lastEditTime = 0
+    pendingEdit = false
+    return sent
+  }
+
+  /** Finalize the current text message (split-safe edit) */
+  const flushText = async (final = false) => {
+    if (!accumulated) return
+
     const now = Date.now()
     if (!final && now - lastEditTime < EDIT_INTERVAL_MS) {
       pendingEdit = true
@@ -97,37 +115,81 @@ export async function streamToTelegram(
       accumulated = text.slice(splitAt)
 
       await safeEditMessage(ctx, chatId, messageId, markdownToTelegramHtml(chunk), chunk)
-      const next = await ctx.api.sendMessage(chatId, "...")
-      messageId = next.message_id
+      await sendNew("...")
       text = accumulated
     }
 
-    const display = final ? formatFinalMessage(text, projectName, result) : markdownToTelegramHtml(text)
-    const rawDisplay = final ? formatFinalMessagePlain(text, projectName, result) : text
-    await safeEditMessage(ctx, chatId, messageId, display || "...", rawDisplay || "...")
+    await safeEditMessage(ctx, chatId, messageId, markdownToTelegramHtml(text), text)
+  }
+
+  /** Update the tools message with current tool lines */
+  const flushTools = async () => {
+    if (toolLines.length === 0) return
+    const text = toolLines.map((l) => `<i>${escapeHtml(l)}</i>`).join("\n")
+    await safeEditMessage(ctx, chatId, messageId, text, toolLines.join("\n"))
+  }
+
+  /** Switch to a new mode, finalizing the previous one */
+  const switchMode = async (newMode: MessageMode) => {
+    if (mode === "text" && accumulated) {
+      await flushText(true)
+      lastTextMessageId = messageId
+    }
+    if (mode === "tools") {
+      await flushTools()
+    }
+    mode = newMode
+    accumulated = ""
+    toolLines = []
   }
 
   const editTimer = setInterval(async () => {
-    if (pendingEdit) await doEdit().catch(() => {})
+    if (pendingEdit && mode === "text") await flushText().catch(() => {})
   }, EDIT_INTERVAL_MS)
 
   try {
     for await (const event of events) {
       if (event.kind === "text_delta") {
-        accumulated += event.text
-        await doEdit().catch(() => {})
-      } else if (event.kind === "turn_boundary") {
-        if (accumulated && !accumulated.endsWith("\n\n")) {
-          accumulated += accumulated.endsWith("\n") ? "\n" : "\n\n"
+        if (mode !== "text") {
+          await switchMode("text")
+          await sendNew("...")
         }
-        await doEdit().catch(() => {})
+        accumulated += event.text
+        await flushText().catch(() => {})
+      } else if (event.kind === "tool_use") {
+        if (mode !== "tools") {
+          await switchMode("tools")
+          await sendNew("...")
+        }
+        const label = event.input ? `${event.name}: ${event.input}` : event.name
+        toolLines.push(label)
+        await flushTools().catch(() => {})
+      } else if (event.kind === "thinking_start") {
+        await switchMode("thinking")
+        await sendNew("<i>Thinking...</i>", "HTML")
+      } else if (event.kind === "thinking_done") {
+        if (mode === "thinking") {
+          const secs = (event.durationMs / 1000).toFixed(1)
+          await safeEditMessage(ctx, chatId, messageId, `<i>Thought for ${secs}s</i>`).catch(() => {})
+        }
+        mode = "none"
       } else if (event.kind === "result") {
         result.sessionId = event.sessionId
         result.cost = event.cost
         result.durationMs = event.durationMs
         result.turns = event.turns
-        if (!accumulated) accumulated = event.text
+        if (!accumulated && event.text) {
+          if (mode !== "text") {
+            await switchMode("text")
+            await sendNew("...")
+          }
+          accumulated = event.text
+        }
       } else if (event.kind === "error") {
+        if (mode !== "text") {
+          await switchMode("text")
+          await sendNew("...")
+        }
         accumulated += `\n\n[Error: ${event.message}]`
       }
     }
@@ -135,15 +197,29 @@ export async function streamToTelegram(
     clearInterval(editTimer)
   }
 
-  await doEdit(true).catch(() => {})
+  // Final edit on the last text message with footer
+  if (mode === "text" && accumulated) {
+    lastTextMessageId = messageId
+  }
+
+  if (lastTextMessageId && accumulated) {
+    const html = markdownToTelegramHtml(accumulated)
+    const footer = formatFooter(projectName, result)
+    const display = footer ? `${html}\n\n${footer}` : html
+    const rawFooter = formatFooterPlain(projectName, result)
+    const rawDisplay = rawFooter ? `${accumulated}\n\n${rawFooter}` : accumulated
+    await safeEditMessage(ctx, chatId, lastTextMessageId, display || "...", rawDisplay || "...").catch(() => {})
+  } else if (!lastTextMessageId && (result.cost !== undefined || result.durationMs !== undefined)) {
+    // No text message was sent -- send footer as standalone
+    const footer = formatFooter(projectName, result)
+    if (footer) await ctx.api.sendMessage(chatId, footer, { parse_mode: "HTML" }).catch(() => {})
+  }
+
   return result
 }
 
-/** Format the final message with metadata footer */
-function formatFinalMessage(text: string, projectName: string, result: StreamResult) {
-  const html = markdownToTelegramHtml(text)
-  const parts = [html]
-
+/** Format metadata footer as HTML */
+function formatFooter(projectName: string, result: StreamResult) {
   const meta: string[] = []
   if (projectName) meta.push(`Project: ${escapeHtml(projectName)}`)
   if (result.cost !== undefined) meta.push(`Cost: $${result.cost.toFixed(4)}`)
@@ -152,18 +228,11 @@ function formatFinalMessage(text: string, projectName: string, result: StreamRes
     meta.push(`Time: ${secs}s`)
   }
   if (result.turns !== undefined && result.turns > 1) meta.push(`Turns: ${result.turns}`)
-
-  if (meta.length > 0) {
-    parts.push("")
-    parts.push(`<i>${meta.join(" | ")}</i>`)
-  }
-
-  return parts.join("\n")
+  return meta.length > 0 ? `<i>${meta.join(" | ")}</i>` : ""
 }
 
-/** Plain text version of final message (used as fallback) */
-function formatFinalMessagePlain(text: string, projectName: string, result: StreamResult) {
-  const parts = [text]
+/** Format metadata footer as plain text */
+function formatFooterPlain(projectName: string, result: StreamResult) {
   const meta: string[] = []
   if (projectName) meta.push(`Project: ${projectName}`)
   if (result.cost !== undefined) meta.push(`Cost: $${result.cost.toFixed(4)}`)
@@ -172,9 +241,5 @@ function formatFinalMessagePlain(text: string, projectName: string, result: Stre
     meta.push(`Time: ${secs}s`)
   }
   if (result.turns !== undefined && result.turns > 1) meta.push(`Turns: ${result.turns}`)
-  if (meta.length > 0) {
-    parts.push("")
-    parts.push(meta.join(" | "))
-  }
-  return parts.join("\n")
+  return meta.join(" | ")
 }


### PR DESCRIPTION
## Summary
- Each assistant text turn becomes a separate Telegram message
- Tool calls consolidated into one message, updated progressively (e.g., "Read: src/index.ts", "Bash: ls -la")
- Thinking shown as "Thinking..." then "Thought for Xs"
- Footer (cost/time/turns) only on last text message
- Expanded stream parser to handle content_block_start/stop, tool_use, input_json_delta, and thinking events

## Test plan
- [ ] Send a prompt that triggers multi-turn response with tool use
- [ ] Verify text, tool calls, and thinking appear as separate Telegram messages
- [ ] Verify tool call message updates progressively as new tools are invoked
- [ ] Verify footer only appears on the final text message

Generated with [Claude Code](https://claude.ai/code)