### PR TITLE
Show voice transcription as blockquote

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -157,7 +157,7 @@ export function createBot(token: string, allowedUserId: number, projectsDir: str
 
     const status = await ctx.reply("Transcribing...")
     const prompt = await transcribeAudio(buffer, "voice.ogg")
-    await ctx.api.editMessageText(ctx.chat.id, status.message_id, `[Voice] ${prompt}`)
+    await ctx.api.editMessageText(ctx.chat.id, status.message_id, `<blockquote>${prompt}</blockquote>`, { parse_mode: "HTML" })
 
     handlePrompt(ctx, prompt).catch((e) => console.error("handlePrompt error:", e))
   })


### PR DESCRIPTION
## Summary
- Voice transcriptions now render as `<blockquote>` in Telegram instead of plain `[Voice] text`

## Test plan
- [ ] Send a voice message to the bot, verify it shows as a blockquote

🤖 Generated with [Claude Code](https://claude.com/claude-code)