### PR TITLE
Add graceful shutdown for active Claude processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { createBot } from "./bot"
+import { stopAll } from "./claude"
 
 const BOT_TOKEN = process.env.BOT_TOKEN
 const ALLOWED_USER_ID = process.env.ALLOWED_USER_ID
@@ -29,6 +30,19 @@ const bot = createBot(BOT_TOKEN, userId, PROJECTS_DIR)
 bot.catch((err) => {
   console.error("Bot error:", err)
 })
+
+let shuttingDown = false
+const shutdown = () => {
+  if (shuttingDown) return
+  shuttingDown = true
+  console.log("Shutting down...")
+  stopAll()
+  bot.stop()
+  process.exit(0)
+}
+
+process.on("SIGTERM", shutdown)
+process.on("SIGINT", shutdown)
 
 bot.start({
   onStart: () => console.log("Bot started"),


### PR DESCRIPTION
## Summary
- Add `stopAll()` to `claude.ts` that aborts all active Claude child processes
- Register `SIGTERM`/`SIGINT` handlers in `index.ts` that call `stopAll()`, stop the bot, and exit cleanly
- Re-entry guard prevents double-fire on repeated signals

Fixes orphaned `claude` CLI processes on bot restart.

## Test plan
- [ ] Start bot, send a message to trigger a Claude process
- [ ] `kill -SIGTERM <pid>` — confirm "Shutting down..." log, clean exit, no orphan processes
- [ ] Verify `Ctrl+C` (SIGINT) also triggers clean shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)