### PR TITLE
Fix voice handler: error handling + transcription timeouts

### DIFF
--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -6,6 +6,18 @@ import { $ } from "bun"
 
 const groq = new Groq()
 const MAX_SIZE = 20 * 1024 * 1024
+const TRANSCRIBE_TIMEOUT = 60_000
+const FFMPEG_TIMEOUT = 30_000
+
+/** Race a promise against a timeout, rejecting with a descriptive error */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms)
+    ),
+  ])
+}
 
 /** Transcribe audio buffer using Groq Whisper, chunking if >20MB */
 export async function transcribeAudio(buffer: Buffer, filename: string) {
@@ -19,7 +31,10 @@ export async function transcribeAudio(buffer: Buffer, filename: string) {
     const inputPath = join(tempDir, filename)
     await Bun.write(inputPath, buffer)
 
-    const probeResult = await $`ffprobe -v error -show_entries format=duration -of csv=p=0 ${inputPath}`.text()
+    const probeResult = await withTimeout(
+      $`ffprobe -v error -show_entries format=duration -of csv=p=0 ${inputPath}`.text(),
+      FFMPEG_TIMEOUT, "ffprobe"
+    )
     const totalDuration = parseFloat(probeResult.trim())
     const numChunks = Math.ceil(buffer.length / MAX_SIZE)
     const chunkDuration = totalDuration / numChunks
@@ -29,7 +44,10 @@ export async function transcribeAudio(buffer: Buffer, filename: string) {
     for (let i = 0; i < numChunks; i++) {
       const start = i * chunkDuration
       const chunkPath = join(tempDir, `chunk_${i}.ogg`)
-      await $`ffmpeg -y -i ${inputPath} -ss ${start} -t ${chunkDuration} -c copy ${chunkPath}`.quiet()
+      await withTimeout(
+        $`ffmpeg -y -i ${inputPath} -ss ${start} -t ${chunkDuration} -c copy ${chunkPath}`.quiet(),
+        FFMPEG_TIMEOUT, "ffmpeg"
+      )
 
       const chunkBuffer = Buffer.from(await Bun.file(chunkPath).arrayBuffer())
       const text = await transcribeChunk(chunkBuffer, `chunk_${i}.ogg`)
@@ -45,9 +63,9 @@ export async function transcribeAudio(buffer: Buffer, filename: string) {
 /** Transcribe a single audio buffer */
 async function transcribeChunk(buffer: Buffer, filename: string) {
   const file = new File([new Uint8Array(buffer)], filename, { type: "audio/ogg" })
-  const response = await groq.audio.transcriptions.create({
-    file,
-    model: "whisper-large-v3-turbo",
-  })
+  const response = await withTimeout(
+    groq.audio.transcriptions.create({ file, model: "whisper-large-v3-turbo" }),
+    TRANSCRIBE_TIMEOUT, "Groq transcription"
+  )
   return response.text
 }


### PR DESCRIPTION
## Summary
- Wrap voice message handler in try/catch — transcription failures now reply with an error message instead of crashing the bot
- Add `withTimeout()` helper in `transcribe.ts` with 60s timeout for Groq API calls and 30s for ffmpeg/ffprobe, preventing indefinite hangs

## Test plan
- [ ] Send a voice message and verify normal transcription still works
- [ ] Simulate Groq API failure (e.g. invalid API key) and verify bot replies with error instead of crashing
- [ ] Verify timeout fires if API hangs (can test by temporarily setting timeout to 1ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)