### PR TITLE
Add pagination to /history command

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -12,7 +12,7 @@ export type SessionInfo = {
 }
 
 const CLAUDE_PROJECTS_DIR = join(homedir(), ".claude", "projects")
-const MAX_SESSIONS = 10
+const MAX_SESSIONS = 50
 
 /** Cache of sessionId -> projectPath, populated during listing */
 const sessionProjectCache = new Map<string, string>()


### PR DESCRIPTION
## Summary
- Increase `MAX_SESSIONS` from 10 to 50 to allow browsing more history
- Paginate `/history` with 5 sessions per page
- Add `<< Prev` / `Next >>` inline buttons for page navigation
- Show page indicator (e.g. `(2/10)`) in title when multiple pages exist
- In-place message editing on page change via callback query

## Test plan
- [ ] `/history` shows first 5 sessions with "Next >>" if more exist
- [ ] Click Next, verify page 2 with both "<< Prev" and "Next >>"
- [ ] Click Prev, verify return to page 1
- [ ] Test with no active project (global mode)
- [ ] Test edge: fewer sessions than page size = no nav buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)