### PR TITLE
Fix auth, env var, and message editing bugs

### DIFF
--- a/src/claude.ts
+++ b/src/claude.ts
@@ -184,12 +184,14 @@ export async function* runClaude(
   const done = new Promise<void>((r) => { resolveCleanup = r })
   userProcesses.set(telegramUserId, { ac, done })
 
+  const env = { ...process.env }
+  delete env.CLAUDECODE
   const proc = spawn({
     cmd: args,
     cwd: projectDir,
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, CLAUDECODE: undefined },
+    env,
     signal: ac.signal,
   })
 


### PR DESCRIPTION
## Summary
- **Auth middleware**: Bot's own updates (pin/edit) triggered "Unauthorized" replies. Skip auth for bot's own ID.
- **CLAUDECODE env var**: `{ CLAUDECODE: undefined }` doesn't remove the key in Bun's spawn, causing Claude CLI to silently produce no output. Fixed with explicit `delete`.
- **Message editing**: ReplyKeyboardMarkup on "..." placeholder made it uneditable. Removed keyboard from streamed messages.

## Test plan
- [ ] Send a message to the bot — should get a response (not just "...")
- [ ] Switch projects — pin should work without "Unauthorized" reply
- [ ] Verify auth still rejects unknown users

🤖 Generated with [Claude Code](https://claude.com/claude-code)