### PR TITLE
Auto-select general project on /new

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -172,9 +172,10 @@ export function createBot(token: string, allowedUserId: number, projectsDir: str
 
   bot.command("new", async (ctx) => {
     const state = getState(ctx.from!.id)
-    if (state.activeProject) {
-      state.sessions.delete(state.activeProject)
+    if (!state.activeProject) {
+      state.activeProject = projectsDir
     }
+    state.sessions.delete(state.activeProject)
     await ctx.reply("Session cleared. Next message starts a fresh conversation.", { reply_markup: idleKeyboard() })
   })
 


### PR DESCRIPTION
## Summary
- When `/new` is used with no active project, auto-selects the general (projects root) project instead of requiring user to go through `/projects` menu first

## Test plan
- [ ] Use `/new` without any project selected — should set general project and clear session
- [ ] Use `/new` with a project already selected — should only clear session (no change)
- [ ] Send a message after `/new` with no prior project — should work immediately without needing `/projects`

🤖 Generated with [Claude Code](https://claude.com/claude-code)