### PR TITLE
Replace regex markdown with marked-based parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "dependencies": {
     "grammy": "^1.35.0",
-    "groq-sdk": "^0.37.0"
+    "groq-sdk": "^0.37.0",
+    "marked": "^17.0.2"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- Replaced hand-rolled regex `markdownToTelegramHtml` with `marked` (AST-based parser) + custom Telegram HTML renderer
- Fixed `safeEditMessage` falling through to plain-text fallback on "message is not modified", which stripped styling from previously rendered messages
- Final edit now sends footer separately if HTML fails, instead of overwriting styled message with raw text

## What was broken
- Nested formatting (`**bold _italic_**`) produced overlapping HTML tags — Telegram rejected
- Unmatched delimiters (odd backticks/asterisks) produced broken HTML — fallback stripped all styling
- Special chars in code spans weren't always escaped — caused parse failures
- On mode switch, identical content re-edit hit "not modified" error, fell through to plain-text fallback

## Test plan
- [ ] Send prompt that triggers tool use followed by text response — verify tool message keeps collapsible quote styling
- [ ] Send prompt that produces nested formatting (bold+italic, bold+code) — verify correct rendering
- [ ] Send prompt that produces code blocks with special chars (`<`, `>`, `&`) — verify proper escaping
- [ ] Verify footer (cost/time/turns) appears correctly after response

🤖 Generated with [Claude Code](https://claude.com/claude-code)