### PR TITLE
Show /stop keyboard while streaming

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -319,7 +319,10 @@ export function createBot(token: string, allowedUserId: number, projectsDir: str
     const projectName = state.activeProject === projectsDir ? "general" : basename(state.activeProject)
 
     const events = runClaude(ctx.from!.id, prompt, state.activeProject, sessionId)
-    const result = await streamToTelegram(ctx, events, projectName)
+    const result = await streamToTelegram(ctx, events, projectName, {
+      startKeyboard: runningKeyboard(),
+      endKeyboard: idleKeyboard(),
+    })
 
     if (result.sessionId) {
       state.sessions.set(state.activeProject, result.sessionId)


### PR DESCRIPTION
## Summary
- `runningKeyboard()` was defined but never used — `/stop` button never appeared during streaming
- First streaming message now attaches the `/stop` keyboard via `reply_markup`
- Footer is sent as a separate message (instead of edited into the last text message) with the idle keyboard attached, avoiding `editMessageText` conflicts with `reply_markup` changes

## Test plan
- [ ] Send a prompt and verify `/stop` button appears in keyboard during streaming
- [ ] Verify idle keyboard (`/projects`, `/history`, `/new`, `/help`) restores after streaming completes
- [ ] Verify footer (cost/time/turns) appears as its own message
- [ ] Test `/stop` mid-stream and confirm keyboard restores to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)