### PR TITLE
Fix MESSAGE_TOO_LONG for long voice transcriptions

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -357,7 +357,11 @@ export function createBot(token: string, allowedUserId: number, projectsDir: str
         reply_parameters: { message_id: ctx.message.message_id },
       })
       prompt = await transcribeAudio(buffer, "voice.ogg")
-      await ctx.api.editMessageText(ctx.chat.id, status.message_id, `<blockquote>${prompt}</blockquote>`, { parse_mode: "HTML" })
+      const maxDisplay = 3800
+      const displayText = prompt.length > maxDisplay
+        ? prompt.slice(0, maxDisplay) + "... (truncated)"
+        : prompt
+      await ctx.api.editMessageText(ctx.chat.id, status.message_id, `<blockquote>${escapeHtml(displayText)}</blockquote>`, { parse_mode: "HTML" })
     } catch (e) {
       console.error("Voice transcription error:", e)
       await ctx.reply(`Transcription failed: ${e instanceof Error ? e.message : "unknown error"}`)


### PR DESCRIPTION
## Summary
- Truncate displayed transcription preview to 3800 chars (within Telegram's 4096 limit) while sending full text to Claude
- Escape HTML in transcription text to prevent parse errors

## Test plan
- [ ] Send a long voice message (>5 min) and verify transcription preview displays without error
- [ ] Verify full transcription is still sent to Claude as the prompt
- [ ] Verify short voice messages still display fully

🤖 Generated with [Claude Code](https://claude.com/claude-code)