### PR TITLE
Add bidirectional file exchange

### DIFF
--- a/scripts/send-file-to-user.ts
+++ b/scripts/send-file-to-user.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env bun
+
+const BLOCKED_PATTERNS = [
+  /^\.env/,
+  /^\.env\..+/,
+  /^credentials/i,
+  /^secrets/i,
+  /\.pem$/,
+  /\.key$/,
+]
+
+const filePath = process.argv[2]
+if (!filePath) {
+  console.error("Usage: send-file-to-user.ts <filepath>")
+  process.exit(1)
+}
+
+const botToken = process.env.BOT_TOKEN
+const chatId = process.env.TELEGRAM_CHAT_ID
+if (!botToken || !chatId) {
+  console.error("Missing BOT_TOKEN or TELEGRAM_CHAT_ID env vars")
+  process.exit(1)
+}
+
+const file = Bun.file(filePath)
+if (!(await file.exists())) {
+  console.error(`File not found: ${filePath}`)
+  process.exit(1)
+}
+
+const basename = filePath.split("/").pop() ?? ""
+const blocked = BLOCKED_PATTERNS.some((p) => p.test(basename))
+if (blocked) {
+  console.error(`Blocked: ${basename} matches sensitive file pattern`)
+  process.exit(1)
+}
+
+const form = new FormData()
+form.append("chat_id", chatId)
+form.append("document", file, basename)
+
+const res = await fetch(`https://api.telegram.org/bot${botToken}/sendDocument`, {
+  method: "POST",
+  body: form,
+})
+
+const data = await res.json()
+if (!data.ok) {
+  console.error(`Telegram API error: ${JSON.stringify(data)}`)
+  process.exit(1)
+}
+
+console.log(`Sent ${basename} to chat ${chatId}`)


### PR DESCRIPTION
## Summary
- **Inbound**: Handle document/photo messages from Telegram — saves to `{project}/user-sent-files/` and includes path in Claude prompt
- **Outbound**: New `scripts/send-file-to-user.ts` that Claude can invoke to send files back to the user. System prompt injected via `--append-system-prompt`. Blocks `.env`, `.pem`, `.key`, and credential files.

## Test plan
- [ ] Send a document to the bot — verify it's saved and Claude acknowledges it
- [ ] Send a photo — verify saved as jpg and Claude can reference it
- [ ] Ask Claude to send a file — verify it runs the script and file arrives in chat
- [ ] Ask Claude to send a .env file — verify it's blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new file download/write paths and enables a model-invoked script to exfiltrate local files to Telegram (with limited filename-based blocking), so mistakes or prompt injection could leak data.
> 
> **Overview**
> Adds **bidirectional file exchange** for the Telegram Claude bot.
> 
> Inbound: document and photo messages are now downloaded from Telegram, saved under `<active-project>/user-sent-files/`, and a prompt hint with the saved path (plus any caption) is injected into the Claude conversation.
> 
> Outbound: introduces `scripts/send-file-to-user.ts` (Bun) to send a local file to the current chat via Telegram’s `sendDocument`, with basic blocking of common sensitive filename patterns; `runClaude` now passes `TELEGRAM_CHAT_ID` into the Claude CLI environment and appends a system prompt instructing Claude how/when to invoke the script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffc32e74c785be6de50f13fb134acd35444e2c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->