### PR TITLE
Fix Cursor Bugbot issues from PR #20

### DIFF
--- a/scripts/send-file-to-user.ts
+++ b/scripts/send-file-to-user.ts
@@ -2,7 +2,6 @@
 
 const BLOCKED_PATTERNS = [
   /^\.env/,
-  /^\.env\..+/,
   /^credentials/i,
   /^secrets/i,
   /\.pem$/,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -375,7 +375,7 @@ export function createBot(token: string, allowedUserId: number, projectsDir: str
 
     const dir = join(state.activeProject, "user-sent-files")
     mkdirSync(dir, { recursive: true })
-    const dest = join(dir, filename)
+    const dest = join(dir, basename(filename))
     writeFileSync(dest, buffer)
     return dest
   }

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -155,7 +155,7 @@ function createStreamParser() {
   }
 }
 
-const SCRIPT_DIR = new URL("../../scripts", import.meta.url).pathname
+const SCRIPT_DIR = new URL("../scripts", import.meta.url).pathname
 
 /** Build system prompt snippet telling Claude how to send files to the user */
 function buildFileSystemPrompt() {


### PR DESCRIPTION
## Summary
- Fix `SCRIPT_DIR` wrong relative path (`../../scripts` -> `../scripts`) — was resolving outside project root
- Sanitize uploaded filename with `basename()` to prevent path traversal writes
- Remove redundant `.env` regex pattern

Addresses all 3 issues reported by Cursor Bugbot on PR #20.

## Test plan
- [ ] Verify file sending works (SCRIPT_DIR resolves correctly)
- [ ] Upload a file via Telegram and confirm it lands in `user-sent-files/`
- [ ] Confirm `.env` files are still blocked by send script

🤖 Generated with [Claude Code](https://claude.com/claude-code)