### PR TITLE
fix: resolve 13 TypeScript errors across 4 files

### DIFF
--- a/scripts/send-file-to-user.ts
+++ b/scripts/send-file-to-user.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+export {}
 
 const BLOCKED_PATTERNS = [
   /^\.env/,

--- a/src/claude.ts
+++ b/src/claude.ts
@@ -214,8 +214,8 @@ export async function* runClaude(
   const done = new Promise<void>((r) => { resolveCleanup = r })
   userProcesses.set(telegramUserId, { ac, done })
 
-  const env = { ...process.env, TELEGRAM_CHAT_ID: String(chatId) }
-  delete env.CLAUDECODE
+  const { CLAUDECODE: _, ...restEnv } = process.env as Record<string, string | undefined>
+  const env = { ...restEnv, TELEGRAM_CHAT_ID: String(chatId) }
   const proc = spawn({
     cmd: args,
     cwd: projectDir,

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -91,9 +91,9 @@ const marked = new Marked({
     checkbox({ checked }) {
       return checked ? "[x] " : "[ ] "
     },
-    text({ tokens, text }) {
-      if (tokens) return this.parser.parseInline(tokens)
-      return escapeHtml(text)
+    text(token) {
+      if ("tokens" in token && token.tokens) return this.parser.parseInline(token.tokens)
+      return escapeHtml(token.text)
     },
   },
 })
@@ -298,6 +298,7 @@ export async function streamToTelegram(
     accumulated = ""
     toolLines = []
     thinkingText = ""
+    return newMode
   }
 
   const editTimer = setInterval(async () => {
@@ -314,7 +315,7 @@ export async function streamToTelegram(
     for await (const event of events) {
       if (event.kind === "text_delta") {
         if (mode !== "text") {
-          await switchMode("text")
+          mode = await switchMode("text")
           if (useDrafts === null) {
             try {
               await ctx.api.sendMessageDraft(chatId, draftId, "...", { parse_mode: "HTML" })
@@ -331,14 +332,14 @@ export async function streamToTelegram(
         await flushText().catch(() => {})
       } else if (event.kind === "tool_use") {
         if (mode !== "tools") {
-          await switchMode("tools")
+          mode = await switchMode("tools")
           await sendNew("...")
         }
         const label = event.input ? `${event.name}: ${event.input}` : event.name
         toolLines.push(label)
         await flushTools().catch(() => {})
       } else if (event.kind === "thinking_start") {
-        await switchMode("thinking")
+        mode = await switchMode("thinking")
         if (useDrafts) {
           await safeSendDraft(ctx, chatId, draftId, "<i>Thinking...</i>", "Thinking...")
         } else {
@@ -346,7 +347,7 @@ export async function streamToTelegram(
         }
       } else if (event.kind === "thinking_delta") {
         if (mode !== "thinking") {
-          await switchMode("thinking")
+          mode = await switchMode("thinking")
           if (useDrafts) {
             await safeSendDraft(ctx, chatId, draftId, "<i>Thinking...</i>", "Thinking...")
           } else {
@@ -378,14 +379,14 @@ export async function streamToTelegram(
         result.turns = event.turns
         if (!accumulated && event.text) {
           if (mode !== "text") {
-            await switchMode("text")
+            mode = await switchMode("text")
             if (!useDrafts) await sendNew("...")
           }
           accumulated = event.text
         }
       } else if (event.kind === "error") {
         if (mode !== "text") {
-          await switchMode("text")
+          mode = await switchMode("text")
           if (!useDrafts) await sendNew("...")
         }
         accumulated += `\n\n[Error: ${event.message}]`


### PR DESCRIPTION
## Summary
- **src/telegram.ts**: Fix `tokens` property access on `Escape | Text` union type; fix `mode` CFA narrowing by returning new mode from `switchMode`
- **src/claude.ts**: Destructure `CLAUDECODE` out of `process.env` instead of `delete` on typed object
- **scripts/send-file-to-user.ts**: Add `export {}` to make file a module (enables top-level `await`)
- **scripts/auto-pr/utils.ts**: `execa` was missing from `node_modules` — fixed by `bun install`

## Test plan
- [x] `bunx tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)