### PR TITLE
Persist bot state to .data/ directory for resume across restarts

### DIFF
--- a/.auto-pr/telegram-claude/issue-51/completed-summary.md
+++ b/.auto-pr/telegram-claude/issue-51/completed-summary.md
@@ -1,0 +1,23 @@
+# Completed: Persist bot state to .data/
+
+## What was implemented
+
+1. **`.gitignore`** — Added `.data/` to prevent persisted state from being tracked by git.
+
+2. **`src/state.ts`** (new) — Persistence module with:
+   - `loadPersistedState()` — Reads `.data/state.json`, validates `activeProject` path exists on disk, converts sessions object to Map. Returns null on any error.
+   - `setActiveProject(state, path)` — Sets activeProject and atomically writes state to disk (write-then-rename).
+   - `updateSession(state, projectPath, sessionId?)` — Sets or deletes a session mapping and persists to disk.
+
+3. **`src/bot.ts`** — Integrated persistence:
+   - `getState()` now loads persisted state on first access via `loadPersistedState()`.
+   - All 9 `state.activeProject = ...` assignments replaced with `setActiveProject()`.
+   - All 6 `state.sessions.set()`/`state.sessions.delete()` calls replaced with `updateSession()`.
+
+## Behavior
+
+- On startup, if `.data/state.json` exists, activeProject and sessions are restored.
+- Every project switch or session change atomically writes to `.data/state.json`.
+- If `.data/state.json` is missing or corrupt, bot starts with fresh empty state.
+- If persisted activeProject path no longer exists on disk, it falls back to empty string.
+- `.data/` directory is created automatically on first state mutation.

--- a/.auto-pr/telegram-claude/issue-51/initial-ramblings.md
+++ b/.auto-pr/telegram-claude/issue-51/initial-ramblings.md
@@ -1,0 +1,38 @@
+# Persist bot state to .data/ directory for resume across restarts
+
+> Mark-Life/telegram-claude#51
+
+## Problem
+
+All bot state (active project, Claude session IDs) is lost on restart. User must re-select project and loses conversation continuity.
+
+## Solution
+
+Store state in `.data/` directory (gitignored), similar to `.claude/` pattern.
+
+### Structure
+
+```
+.data/
+  sessions.json    # { "/path/to/project": "session-id" }
+  active-project   # plain text path
+```
+
+### Behavior
+
+- Created on first write if missing
+- Load on startup, write-through on state changes
+- Atomic writes (write-then-rename) for safety
+- Add `.data/` to `.gitignore`
+
+### What to persist
+- `activeProject` — no re-selecting project on restart
+- `sessions` map — resume Claude conversations after restart
+
+### What NOT to persist
+- `queue`, `composeMessages` — ephemeral
+- Process refs / AbortControllers — runtime-only
+- Telegram message IDs — stale after restart
+
+### Side benefit
+Also clean up audio buffers (null refs after use) as part of this work.

--- a/.auto-pr/telegram-claude/issue-51/plan-implementation.md
+++ b/.auto-pr/telegram-claude/issue-51/plan-implementation.md
@@ -1,0 +1,72 @@
+# Implementation Checklist: Persist bot state to .data/
+
+- [x] **Task 1: Add `.data/` to `.gitignore`**
+  - Files: `.gitignore`
+  - Changes: Add `.data/` line to the gitignore file
+  - Acceptance: `.gitignore` contains `.data/` entry, `git status` does not show `.data/` contents
+
+- [x] **Task 2: Create `src/state.ts` persistence module**
+  - Files: `src/state.ts` (new file)
+  - Changes:
+    - Define `PersistedState` interface: `{ activeProject: string; sessions: Record<string, string> }`
+    - Constants: `DATA_DIR = ".data"`, `STATE_FILE = join(DATA_DIR, "state.json")`
+    - `loadPersistedState()` — reads `STATE_FILE`, parses JSON, validates `activeProject` path exists via `existsSync()`, converts `sessions` object to `Map<string, string>` via `new Map(Object.entries(...))`. Returns `{ activeProject, sessions }` or `null` on any error (missing file, parse failure)
+    - `saveState(activeProject, sessions)` — private helper. `mkdirSync(DATA_DIR, { recursive: true })`, serializes to JSON (`Object.fromEntries` for Map), writes to `STATE_FILE + ".tmp"` then `renameSync` to `STATE_FILE` (atomic write)
+    - `setActiveProject(state, path)` — sets `state.activeProject = path`, calls `saveState()`
+    - `updateSession(state, projectPath, sessionId?)` — if `sessionId` provided: `state.sessions.set(projectPath, sessionId)`, else `state.sessions.delete(projectPath)`. Calls `saveState()`
+    - State param type: `{ activeProject: string; sessions: Map<string, string> }` (matches `UserState` shape without importing the full interface)
+    - Add JSDoc on all exported functions
+  - Acceptance: File compiles with no errors. `loadPersistedState()` returns `null` when no `.data/state.json` exists. `setActiveProject` and `updateSession` create `.data/state.json` with correct JSON structure
+
+- [x] **Task 3: Integrate `loadPersistedState` into `getState()` in bot.ts**
+  - Files: `src/bot.ts`
+  - Changes:
+    - Add import: `import { loadPersistedState, setActiveProject, updateSession } from "./state"`
+    - Modify `getState()` (line 98-105): replace the default state creation with:
+      ```typescript
+      const persisted = loadPersistedState();
+      state = {
+        activeProject: persisted?.activeProject ?? "",
+        sessions: persisted?.sessions ?? new Map(),
+        queue: [],
+      };
+      ```
+  - Acceptance: On startup, if `.data/state.json` exists with valid data, `getState()` returns state with persisted `activeProject` and `sessions`. If file missing/corrupt, returns fresh empty state as before
+
+- [x] **Task 4: Replace all `state.activeProject = ...` assignments with `setActiveProject()`**
+  - Files: `src/bot.ts`
+  - Changes: Replace each direct assignment with `setActiveProject(state, value)` at these locations:
+    - Line 222: `state.activeProject = fullPath` → `setActiveProject(state, fullPath)` (project selection callback)
+    - Line 392: `state.activeProject = projectsDir` → `setActiveProject(state, projectsDir)` (`/new` command reset)
+    - Line 569: `state.activeProject = cachedProject` → `setActiveProject(state, cachedProject)` (history session resume)
+    - Line 681: `state.activeProject = plan.projectPath` → `setActiveProject(state, plan.projectPath)` (plan execute-new)
+    - Line 702: `state.activeProject = plan.projectPath` → `setActiveProject(state, plan.projectPath)` (plan execute-resume)
+    - Line 762: `state.activeProject = projectsDir` → `setActiveProject(state, projectsDir)` (default fallback in handlePrompt)
+    - Line 770: `state.activeProject = plan.projectPath` → `setActiveProject(state, plan.projectPath)` (plan context in handlePrompt)
+    - Line 993: `state.activeProject = projectsDir` → `setActiveProject(state, projectsDir)` (voice fallback)
+    - Line 1043: `state.activeProject = projectsDir` → `setActiveProject(state, projectsDir)` (file upload fallback)
+  - Acceptance: No remaining `state.activeProject = ` assignments in bot.ts (only reads/comparisons remain). Every project switch writes to `.data/state.json`
+
+- [x] **Task 5: Replace all `state.sessions.set/delete` calls with `updateSession()`**
+  - Files: `src/bot.ts`
+  - Changes: Replace each direct sessions mutation with `updateSession()`:
+    - Line 394: `state.sessions.delete(state.activeProject)` → `updateSession(state, state.activeProject)` (`/new` command)
+    - Line 577: `state.sessions.set(state.activeProject, sessionId)` → `updateSession(state, state.activeProject, sessionId)` (history resume)
+    - Line 682: `state.sessions.delete(plan.projectPath)` → `updateSession(state, plan.projectPath)` (plan new-session)
+    - Line 704: `state.sessions.set(plan.projectPath, plan.sessionId)` → `updateSession(state, plan.projectPath, plan.sessionId)` (plan resume)
+    - Line 772: `state.sessions.set(plan.projectPath, plan.sessionId)` → `updateSession(state, plan.projectPath, plan.sessionId)` (plan context)
+    - Line 820: `state.sessions.set(state.activeProject, result.sessionId)` → `updateSession(state, state.activeProject, result.sessionId)` (after Claude result)
+  - Acceptance: No remaining `state.sessions.set(` or `state.sessions.delete(` in bot.ts. Every session change writes to `.data/state.json`
+
+- [x] **Task 6: Verify everything works together**
+  - Files: all modified files (`src/state.ts`, `src/bot.ts`, `.gitignore`)
+  - Changes: none (verification only)
+  - Acceptance:
+    - `bun run lint` passes with no errors
+    - `bun run src/index.ts` starts without errors
+    - `.data/` directory is created on first state mutation
+    - `.data/state.json` contains correct JSON after selecting a project
+    - After restarting the bot, `activeProject` and `sessions` are restored from `.data/state.json`
+    - If `.data/state.json` is deleted, bot starts cleanly with fresh state
+    - If persisted `activeProject` path no longer exists on disk, it falls back to empty string
+    - `.data/` is not tracked by git

--- a/.auto-pr/telegram-claude/issue-51/plan.md
+++ b/.auto-pr/telegram-claude/issue-51/plan.md
@@ -1,0 +1,151 @@
+# Plan: Persist bot state to .data/ directory
+
+## Summary
+
+All bot state (`activeProject`, `sessions` map) lives in-memory and is lost on restart. This forces the user to re-select their project and breaks Claude conversation continuity. We'll persist these two pieces of state to a `.data/` directory using atomic writes, with write-through on every mutation and load-on-startup semantics. Single-user assumption (matches `ALLOWED_USER_ID` design).
+
+## Approach
+
+Create a new `src/state.ts` module with load/save functions. Replace direct `state.activeProject = ...` and `state.sessions.set/delete(...)` calls in `bot.ts` with helper functions that mutate-and-persist atomically. Load persisted state in `getState()` on first access.
+
+## Architectural decisions
+
+**New module vs inline in bot.ts** — Separate `src/state.ts` keeps persistence logic isolated from bot handlers. `bot.ts` is already large; adding file I/O helpers there would push it further.
+
+**Flat files vs single JSON blob** — Single `state.json` file containing both `activeProject` and `sessions`. Simpler than two files, single atomic write, and the data is tiny. The issue suggested two files but a single file is simpler with no downside.
+
+**Centralized mutation helpers** — Instead of adding `saveState()` calls at 15+ mutation sites, expose `setActiveProject(state, path)` and `updateSession(state, project, sessionId?)` that both mutate and persist. This reduces the chance of forgetting a write-through.
+
+**Validate on load** — Check that the persisted `activeProject` path still exists on disk. If not, fall back to empty string (same as fresh state). Stale session IDs are harmless — Claude CLI handles invalid session IDs gracefully.
+
+## Key code snippets
+
+### src/state.ts
+
+```typescript
+import { existsSync, mkdirSync, renameSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const DATA_DIR = ".data";
+const STATE_FILE = join(DATA_DIR, "state.json");
+
+interface PersistedState {
+  activeProject: string;
+  sessions: Record<string, string>;
+}
+
+/** Load persisted state from disk, returns null if none exists */
+export function loadPersistedState() {
+  try {
+    const raw = readFileSync(STATE_FILE, "utf-8");
+    const data: PersistedState = JSON.parse(raw);
+    // Validate activeProject path still exists
+    const activeProject = data.activeProject && existsSync(data.activeProject)
+      ? data.activeProject
+      : "";
+    return {
+      activeProject,
+      sessions: new Map(Object.entries(data.sessions ?? {})),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Atomically write state to disk */
+function saveState(activeProject: string, sessions: Map<string, string>) {
+  mkdirSync(DATA_DIR, { recursive: true });
+  const data: PersistedState = {
+    activeProject,
+    sessions: Object.fromEntries(sessions),
+  };
+  const tmp = STATE_FILE + ".tmp";
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, STATE_FILE);
+}
+
+/** Set activeProject and persist */
+export function setActiveProject(
+  state: { activeProject: string; sessions: Map<string, string> },
+  path: string
+) {
+  state.activeProject = path;
+  saveState(state.activeProject, state.sessions);
+}
+
+/** Set or delete a session and persist */
+export function updateSession(
+  state: { activeProject: string; sessions: Map<string, string> },
+  projectPath: string,
+  sessionId?: string
+) {
+  if (sessionId) {
+    state.sessions.set(projectPath, sessionId);
+  } else {
+    state.sessions.delete(projectPath);
+  }
+  saveState(state.activeProject, state.sessions);
+}
+```
+
+### bot.ts changes — getState()
+
+```typescript
+import { loadPersistedState, setActiveProject, updateSession } from "./state";
+
+function getState(id: number): UserState {
+  let state = userStates.get(id);
+  if (!state) {
+    const persisted = loadPersistedState();
+    state = {
+      activeProject: persisted?.activeProject ?? "",
+      sessions: persisted?.sessions ?? new Map(),
+      queue: [],
+    };
+    userStates.set(id, state);
+  }
+  return state;
+}
+```
+
+### bot.ts changes — mutation sites (example)
+
+```typescript
+// Before:
+state.activeProject = fullPath;
+// After:
+setActiveProject(state, fullPath);
+
+// Before:
+state.sessions.set(state.activeProject, result.sessionId);
+// After:
+updateSession(state, state.activeProject, result.sessionId);
+
+// Before:
+state.sessions.delete(state.activeProject);
+// After:
+updateSession(state, state.activeProject); // no sessionId = delete
+```
+
+## Scope boundaries
+
+- **Out of scope**: Persisting queue, compose state, pending plans, message IDs — all ephemeral/runtime-only per the issue.
+- **Out of scope**: Multi-user persistence — the bot is single-user by design (`ALLOWED_USER_ID`).
+- **Out of scope**: Audio buffer cleanup — the issue mentions it as a side benefit but it's unrelated to state persistence and should be a separate change.
+- **Out of scope**: Migration from any previous state format (there is none).
+
+## Risks
+
+1. **Missing write-through**: 15+ mutation sites need updating. A missed site means that mutation won't persist. Mitigated by using find-and-replace for `state.activeProject =` and `state.sessions.set/delete`.
+2. **Stale project path**: User renames/deletes a project directory between restarts. Mitigated by validating path existence on load.
+3. **File permission issues**: `.data/` in the working directory could fail if CWD changes. Low risk since the bot runs from a fixed directory.
+
+## Alternative approaches
+
+**Proxy/getter-setter on UserState** — Wrap state object with a Proxy that auto-persists on property set. Eliminates risk of missed write-throughs. Rejected: too clever, harder to debug, and Proxy behavior with Maps is tricky.
+
+**SQLite/LevelDB** — Proper embedded database. Rejected: massive overkill for persisting two small values. Adds a dependency.
+
+**Two separate files (as in the issue)** — `active-project` + `sessions.json`. Rejected: single `state.json` is simpler, and atomic write of both together avoids inconsistent state between the two files.
+
+**Persist on shutdown only** — Save state in the SIGTERM/SIGINT handler. Rejected: doesn't survive crashes or `kill -9`, and the data is small enough that write-through on every mutation is fine.

--- a/.auto-pr/telegram-claude/issue-51/prompt-implement.md
+++ b/.auto-pr/telegram-claude/issue-51/prompt-implement.md
@@ -1,0 +1,31 @@
+You are an implementation agent. Your job is to follow the checklist in @.auto-pr/telegram-claude/issue-51/plan-implementation.md task by task.
+
+The original issue is described in @.auto-pr/telegram-claude/issue-51/initial-ramblings.md — this is background context only. Do NOT decide on your own whether the issue is "done". Your ONLY source of truth is the checklist.
+
+The code for this project lives primarily at `./`.
+
+## How to work
+
+1. Read @.auto-pr/telegram-claude/issue-51/plan-implementation.md — Find the highest priority (`- [ ]`) task to work. This should be the one YOU decide has the highest priority. Not necessarily the first one
+2. Execute that task (edit files, run commands, whatever the task says)
+3. After completing it, update @.auto-pr/telegram-claude/issue-51/plan-implementation.md to change `- [ ]` to `- [x]` for that task
+4. Make a git commit ex: `feat(scope): description` or `fix(scope): description`
+5. Move to the next unchecked task. Repeat until all tasks are done or you run out of turns.
+
+Do NOT push to remote — the pipeline handles that.
+Do NOT stop until all tasks and phases are completed.
+
+## When ALL checkboxes are `- [x]`
+
+Write @.auto-pr/telegram-claude/issue-51/completed-summary.md with a brief summary of everything that was implemented. This file signals completion — do NOT create it if ANY tasks remain unchecked.
+
+## Code quality rules
+
+- Do not add unnecessary comments or jsdocs to code you write.
+- Do not use `any` or `unknown` types — use proper typing.
+- Follow existing codebase patterns and conventions (check nearby files for reference).
+- Do NOT skip tasks just because the end result already looks correct.
+- Follow the checklist literally — if a task says "commit", make a commit. If it says "verify", run the verification.
+- If you encounter something unexpected, use your best judgment and proceed.
+- Fixing a known issue later instead of now is not simplicity — if you see a bug or problem in the area you're working on, fix it.
+- Adding a second primitive for something we already have a primitive for is not simplicity — reuse existing abstractions instead of creating parallel ones (exceptions might exist, but don't use it as an easy way out).

--- a/.auto-pr/telegram-claude/issue-51/prompt-plan-implementation.md
+++ b/.auto-pr/telegram-claude/issue-51/prompt-plan-implementation.md
@@ -1,0 +1,32 @@
+You are breaking down a plan into a detailed, ordered implementation checklist.
+
+Read the issue in @.auto-pr/telegram-claude/issue-51/initial-ramblings.md, the research in @.auto-pr/telegram-claude/issue-51/research.md, and the plan in @.auto-pr/telegram-claude/issue-51/plan.md.
+
+**CRITICAL RULES:**
+- Do **NOT** implement the issue. Do not create, modify, or delete any project source files.
+- Your **ONLY** deliverable is writing the file @.auto-pr/telegram-claude/issue-51/plan-implementation.md.
+
+The code for this project lives primarily at `./`.
+
+Write @.auto-pr/telegram-claude/issue-51/plan-implementation.md with:
+
+- An **ordered task list using markdown checkboxes** (`- [ ]` for each task)
+- Each task should be small enough to implement in one focused session
+- For each task:
+  - **Files to modify** — specific file paths
+  - **What to change** — concrete description of the changes (not vague like "update the component")
+  - **Acceptance criteria** — how to verify this task is done correctly
+- Tasks should be ordered so each builds on the previous (no forward dependencies)
+- Include any necessary setup tasks (new files to create, dependencies to add, etc.)
+- The final task should always be "verify everything works together"
+
+IMPORTANT: Every task MUST use the `- [ ]` checkbox format. Example:
+
+```
+- [ ] **Task 1: Create the API endpoint**
+  - Files: `src/server/routes/foo.ts`
+  - Changes: Add GET /api/foo endpoint that returns...
+  - Acceptance: Endpoint responds with 200 and correct shape
+```
+
+Be specific enough that a developer could follow this checklist without needing to re-read the research or plan.

--- a/.auto-pr/telegram-claude/issue-51/prompt-plan.md
+++ b/.auto-pr/telegram-claude/issue-51/prompt-plan.md
@@ -1,0 +1,26 @@
+You are a senior developer planning the implementation for a GitHub issue.
+
+Read the issue in @.auto-pr/telegram-claude/issue-51/initial-ramblings.md and the research in @.auto-pr/telegram-claude/issue-51/research.md.
+
+**CRITICAL RULES:**
+- Do **NOT** implement the issue. Do not create, modify, or delete any project source files.
+- Your **ONLY** deliverable is writing the file @.auto-pr/telegram-claude/issue-51/plan.md.
+- Read the actual source files before suggesting changes. Base the plan on what the code actually does, not assumptions.
+
+The code for this project lives primarily at `./`.
+
+Write @.auto-pr/telegram-claude/issue-51/plan.md containing:
+
+1. **Summary** — what we're building and why (1-2 paragraphs)
+2. **Approach** — the high-level technical approach chosen
+3. **Architectural decisions** — any significant choices made and why (e.g., which component pattern, state management approach, API structure)
+4. **Key code snippets** — include concrete code examples showing the important parts of the implementation (function signatures, component structure, schema changes, etc.)
+5. **Scope boundaries** — what is explicitly out of scope to keep the change focused
+6. **Risks** — anything that could go wrong or needs special attention during implementation
+7. **Alternative approaches** — a brief section listing other valid ways to solve this problem. For each alternative, include: the approach name, a one-liner on how it works, and why the chosen approach was preferred. Consider industry best practices, common patterns, and obvious alternatives. This section is for PR reviewers only — it will NOT be used in the implementation plan.
+
+**Design principles to follow:**
+- Fixing a known issue later instead of now is not simplicity — if the plan touches an area with a known bug, address it.
+- Adding a second primitive for something we already have a primitive for is not simplicity — reuse existing abstractions.
+
+Keep it concise and focused on decisions, not on repeating the research.

--- a/.auto-pr/telegram-claude/issue-51/prompt-research.md
+++ b/.auto-pr/telegram-claude/issue-51/prompt-research.md
@@ -1,0 +1,27 @@
+You are a senior developer researching a codebase to prepare for implementing a GitHub issue.
+
+## Your task
+
+Read the issue description in @.auto-pr/telegram-claude/issue-51/initial-ramblings.md and then **research the codebase in depth** to understand what would be involved in implementing it.
+
+**CRITICAL RULES:**
+- Do **NOT** implement the issue. Do not create, modify, or delete any project source files.
+- Your **ONLY** deliverable is writing the file @.auto-pr/telegram-claude/issue-51/research.md.
+- If the issue seems trivial, research it anyway — document the relevant files, patterns, and context.
+
+## Where to look
+
+The code for this project lives primarily at `./`. Start your investigation there but explore any related files across the monorepo.
+
+Read every relevant file in full. Understand how the system works deeply — its architecture, data flow, and all its specificities. Do not skim. Do not stop researching until you have a thorough understanding of every part of the codebase that this issue touches.
+
+## What to write in @.auto-pr/telegram-claude/issue-51/research.md
+
+1. **Relevant files** — every file that would need to be read or modified, with brief descriptions of what each does
+2. **Existing patterns** — how similar features are currently implemented in this codebase (naming conventions, folder structure, component patterns, API patterns)
+3. **Dependencies** — libraries, utilities, shared code, and services that are relevant
+4. **Potential impact areas** — what else might break or need updating (tests, types, imports, configs)
+5. **Edge cases and constraints** — anything tricky that the implementation should watch out for
+6. **Reference implementations** — if there's a similar feature already built, document it as a reference
+
+Be thorough. Keep researching until you have complete understanding — missing information here means a worse plan later.

--- a/.auto-pr/telegram-claude/issue-51/research.md
+++ b/.auto-pr/telegram-claude/issue-51/research.md
@@ -1,0 +1,130 @@
+# Research: Persist bot state to .data/ directory
+
+## Relevant Files
+
+### Must Modify
+
+- **`src/bot.ts`** — Core state management. Contains `UserState` interface, `userStates` Map, `getState()` function, and all state mutations (`activeProject` assignment, `sessions.set/delete`). Every place that mutates `activeProject` or `sessions` needs a write-through call.
+- **`.gitignore`** — Add `.data/` entry.
+
+### Must Read (context)
+
+- **`src/index.ts`** — Entry point. State loading should happen here before `bot.start()`. The startup notification could also confirm restored state.
+- **`src/claude.ts`** — `runClaude()` receives `sessionId` param from bot.ts. No changes needed but important to understand session flow.
+- **`src/telegram.ts`** — `streamToTelegram()` returns `StreamResult` with `sessionId`. Bot.ts reads this to update sessions map. No changes needed.
+- **`src/history.ts`** — Already reads Claude session files from `~/.claude/projects/`. Our persistence is separate — we're persisting which session is active per project, not session contents.
+
+## Existing Patterns
+
+### State Management (bot.ts)
+- `userStates = new Map<number, UserState>()` — top-level module-scoped Map
+- `getState(id)` — lazy-init pattern: creates default state if missing, returns mutable reference
+- State mutations are scattered throughout handlers — not centralized:
+  - `activeProject` set at: lines 222, 392, 569, 681, 702, 761-762, 770, 992-993, 1042-1043
+  - `sessions.set()` at: lines 577, 704, 772, 820
+  - `sessions.delete()` at: lines 394, 682
+
+### File I/O (already used in bot.ts)
+- `writeFileSync` — already imported (line 6), used for saving uploaded files
+- `mkdirSync` — already imported (line 2), used for creating `user-sent-files/`
+- `readFileSync` — already imported (line 4), used for reading plan files
+- `readdirSync`, `statSync` — already imported for listing projects
+
+### Naming / Structure
+- Project uses sync I/O throughout (no async file ops)
+- Functional style with module-level state
+- No existing persistence layer or data directory
+
+## Dependencies
+
+- **Node.js `fs`** — already imported in bot.ts (`writeFileSync`, `mkdirSync`, `readFileSync`, `existsSync` needed)
+- **Node.js `path`** — already imported (`join`, `basename`)
+- **Node.js `os`** — may need `tmpdir()` for atomic writes, or just use `.data/` as temp location
+- No new external deps needed
+
+## Potential Impact Areas
+
+### State Mutation Points (need write-through)
+
+1. **`activeProject` changes:**
+   - Project selection callback (line ~222): `state.activeProject = fullPath`
+   - `/new` command (line ~392): `state.activeProject = projectsDir` (reset to root)
+   - History session resume (line ~569): `state.activeProject = cachedProject`
+   - Plan execute-new (line ~681): `state.activeProject = plan.projectPath`
+   - Plan execute-resume (line ~702): `state.activeProject = plan.projectPath`
+   - Default fallbacks (lines ~761, ~992, ~1042): `state.activeProject = projectsDir`
+   - Plan context in handlePrompt (line ~770): `state.activeProject = plan.projectPath`
+
+2. **`sessions` changes:**
+   - History resume (line ~577): `state.sessions.set(activeProject, sessionId)`
+   - Plan resume (lines ~704, ~772): `state.sessions.set(projectPath, sessionId)`
+   - After Claude result (line ~820): `state.sessions.set(activeProject, result.sessionId)`
+   - `/new` command (line ~394): `state.sessions.delete(activeProject)`
+   - Plan new-session (line ~682): `state.sessions.delete(projectPath)`
+
+### What NOT to persist (per issue)
+- `queue` — runtime only, contains `Context` objects (not serializable)
+- `composeMessages` — ephemeral compose mode state
+- `composeStatusMessageId`, `queueStatusMessageId` — Telegram message IDs, stale after restart
+- `pendingPlan` — runtime plan interaction state
+
+### Startup Loading
+- `index.ts` calls `createBot()` which returns bot instance. State load should happen inside `createBot()` or as a separate init function called before `bot.start()`.
+- `getState()` is the natural place to integrate: on first call for a user, check if persisted state exists and load it instead of creating empty state.
+
+## Edge Cases and Constraints
+
+1. **Atomic writes**: Issue specifies write-then-rename. Use `writeFileSync` to a temp file in `.data/`, then `renameSync` to final path. This prevents corruption if process crashes mid-write.
+
+2. **Map serialization**: `sessions` is a `Map<string, string>`. JSON doesn't natively serialize Maps. Need `Object.fromEntries()` for writing, `new Map(Object.entries())` for reading.
+
+3. **Single user assumption**: Current code uses `Map<number, UserState>` keyed by user ID, but `.env` only allows one `ALLOWED_USER_ID`. The `.data/` structure in the issue (`sessions.json`, `active-project`) assumes single-user. Can simplify — no need to key by user ID in the files.
+
+4. **Default `activeProject`**: Empty string `""` vs `projectsDir` — some code paths default to `projectsDir` when empty. Persisted value should be the actual project path, not empty string.
+
+5. **Race conditions**: Multiple write-throughs could happen in quick succession (e.g., project switch + session set). Since everything is synchronous and single-threaded in Bun, this is fine.
+
+6. **Missing `.data/` directory**: Must `mkdirSync({ recursive: true })` before first write.
+
+7. **Invalid persisted state**: Project path might no longer exist after restart. Should validate `activeProject` path exists on load; fall back to empty/projectsDir if not.
+
+8. **Audio buffer cleanup**: Issue mentions cleaning up audio buffer null refs — this refers to the voice transcription flow in bot.ts where `Buffer` objects from `transcribeAudio` could be nulled after use. Minor cleanup.
+
+## Reference Implementations
+
+### Similar pattern: `src/history.ts`
+- Reads structured data from files (`~/.claude/projects/` JSONL files)
+- Uses `readdirSync`, `readFileSync`, `statSync`
+- Parses JSON from files
+- Returns typed data structures
+- Good reference for file reading patterns
+
+### Similar pattern: File save in `bot.ts`
+- `saveUploadedFile()` (around line 1050+) demonstrates:
+  - `mkdirSync(dir, { recursive: true })`
+  - `writeFileSync(filePath, buffer)`
+  - Already used pattern for creating directories and writing files
+
+### Atomic write reference
+```typescript
+// Standard atomic write pattern
+import { writeFileSync, renameSync } from "node:fs";
+const tmpPath = filePath + ".tmp";
+writeFileSync(tmpPath, data);
+renameSync(tmpPath, filePath);
+```
+
+## Implementation Approach Summary
+
+1. Create a `src/state.ts` module (or add to bot.ts) with:
+   - `loadState(userId)` — read `.data/sessions.json` + `.data/active-project`
+   - `saveActiveProject(path)` — atomic write to `.data/active-project`
+   - `saveSessions(sessions)` — atomic write to `.data/sessions.json`
+
+2. Modify `getState()` to load persisted state on first call
+
+3. Add write-through calls at every `activeProject` assignment and `sessions.set/delete`
+
+4. Add `.data/` to `.gitignore`
+
+5. Alternatively, wrap state mutations in helper functions (e.g., `setActiveProject(state, path)`, `setSession(state, project, sessionId)`) that both mutate and persist — this centralizes the write-through logic instead of sprinkling save calls everywhere.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ bun.lock
 
 # auto-pr working files
 .auto-pr/
+
+# persisted bot state
+.data/

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -15,6 +15,7 @@ import {
   listOpenPRs,
 } from "./git";
 import { getSessionProject, listAllSessions } from "./history";
+import { loadPersistedState, setActiveProject, updateSession } from "./state";
 import { streamToTelegram } from "./telegram";
 import { transcribeAudio } from "./transcribe";
 
@@ -98,7 +99,12 @@ function getUserId(ctx: Context) {
 function getState(id: number): UserState {
   let state = userStates.get(id);
   if (!state) {
-    state = { activeProject: "", sessions: new Map(), queue: [] };
+    const persisted = loadPersistedState();
+    state = {
+      activeProject: persisted?.activeProject ?? "",
+      sessions: persisted?.sessions ?? new Map(),
+      queue: [],
+    };
     userStates.set(id, state);
   }
   return state;
@@ -219,7 +225,7 @@ export function createBot(
 
     const state = getState(ctx.from.id);
     const chatId = ctx.chat!.id;
-    state.activeProject = fullPath;
+    setActiveProject(state, fullPath);
     state.queue = [];
     state.pendingPlan = undefined;
     state.composeMessages = undefined;
@@ -389,9 +395,9 @@ export function createBot(
   bot.command("new", async (ctx) => {
     const state = getState(getUserId(ctx));
     if (!state.activeProject) {
-      state.activeProject = projectsDir;
+      setActiveProject(state, projectsDir);
     }
-    state.sessions.delete(state.activeProject);
+    updateSession(state, state.activeProject);
     state.queue = [];
     state.pendingPlan = undefined;
     state.composeMessages = undefined;
@@ -566,7 +572,7 @@ export function createBot(
 
     const cachedProject = getSessionProject(sessionId);
     if (cachedProject) {
-      state.activeProject = cachedProject;
+      setActiveProject(state, cachedProject);
     }
 
     if (!state.activeProject) {
@@ -574,7 +580,7 @@ export function createBot(
       return;
     }
 
-    state.sessions.set(state.activeProject, sessionId);
+    updateSession(state, state.activeProject, sessionId);
     const chatId = ctx.chat!.id;
     const projectName = basename(state.activeProject);
     await ctx.answerCallbackQuery({ text: "Session resumed" });
@@ -678,8 +684,8 @@ export function createBot(
       return;
     }
 
-    state.activeProject = plan.projectPath;
-    state.sessions.delete(plan.projectPath);
+    setActiveProject(state, plan.projectPath);
+    updateSession(state, plan.projectPath);
     state.pendingPlan = undefined;
     await ctx.answerCallbackQuery({ text: "Executing plan (new session)..." });
     await ctx.editMessageText("Executing plan (new session)...");
@@ -699,9 +705,9 @@ export function createBot(
       return;
     }
 
-    state.activeProject = plan.projectPath;
+    setActiveProject(state, plan.projectPath);
     if (plan.sessionId) {
-      state.sessions.set(plan.projectPath, plan.sessionId);
+      updateSession(state, plan.projectPath, plan.sessionId);
     }
     state.pendingPlan = undefined;
     await ctx.answerCallbackQuery({
@@ -759,7 +765,7 @@ export function createBot(
     const state = getState(userId);
 
     if (!state.activeProject) {
-      state.activeProject = projectsDir;
+      setActiveProject(state, projectsDir);
       await ctx.reply("No project selected. Using General (all projects).", {
         reply_markup: mainKeyboard,
       });
@@ -767,9 +773,9 @@ export function createBot(
 
     if (state.pendingPlan) {
       const plan = state.pendingPlan;
-      state.activeProject = plan.projectPath;
+      setActiveProject(state, plan.projectPath);
       if (plan.sessionId) {
-        state.sessions.set(plan.projectPath, plan.sessionId);
+        updateSession(state, plan.projectPath, plan.sessionId);
       }
       state.pendingPlan = undefined;
       const feedbackPrompt = `Plan feedback from user: ${prompt}\n\nRevise the plan based on this feedback. Do not execute yet — present the updated plan.`;
@@ -817,7 +823,7 @@ export function createBot(
           branchName,
         });
         if (result.sessionId) {
-          state.sessions.set(state.activeProject, result.sessionId);
+          updateSession(state, state.activeProject, result.sessionId);
         }
         if (result.planPath) {
           stopClaude(userId);
@@ -990,7 +996,7 @@ export function createBot(
     const state = getState(ctx.from.id);
 
     if (!state.activeProject) {
-      state.activeProject = projectsDir;
+      setActiveProject(state, projectsDir);
       await ctx.reply("No project selected. Using General (all projects).", {
         reply_markup: mainKeyboard,
       });
@@ -1040,7 +1046,7 @@ export function createBot(
   ) {
     const state = getState(getUserId(ctx));
     if (!state.activeProject) {
-      state.activeProject = projectsDir;
+      setActiveProject(state, projectsDir);
       await ctx.reply("No project selected. Using General (all projects).", {
         reply_markup: mainKeyboard,
       });

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,71 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+interface PersistedState {
+  activeProject: string;
+  sessions: Record<string, string>;
+}
+
+interface BotState {
+  activeProject: string;
+  sessions: Map<string, string>;
+}
+
+const DATA_DIR = ".data";
+const STATE_FILE = join(DATA_DIR, "state.json");
+
+/** Load persisted state from disk. Returns null if file missing or corrupt. */
+export function loadPersistedState() {
+  try {
+    const text = readFileSync(STATE_FILE, "utf-8");
+    const parsed = JSON.parse(text) as PersistedState;
+
+    const activeProject =
+      parsed.activeProject && existsSync(parsed.activeProject)
+        ? parsed.activeProject
+        : "";
+
+    const sessions = new Map(Object.entries(parsed.sessions ?? {}));
+
+    return { activeProject, sessions };
+  } catch {
+    return null;
+  }
+}
+
+function saveState(activeProject: string, sessions: Map<string, string>) {
+  mkdirSync(DATA_DIR, { recursive: true });
+  const data: PersistedState = {
+    activeProject,
+    sessions: Object.fromEntries(sessions),
+  };
+  const tmp = `${STATE_FILE}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, STATE_FILE);
+}
+
+/** Set active project and persist to disk. */
+export function setActiveProject(state: BotState, path: string) {
+  state.activeProject = path;
+  saveState(state.activeProject, state.sessions);
+}
+
+/** Update or delete a session mapping and persist to disk. */
+export function updateSession(
+  state: BotState,
+  projectPath: string,
+  sessionId?: string
+) {
+  if (sessionId) {
+    state.sessions.set(projectPath, sessionId);
+  } else {
+    state.sessions.delete(projectPath);
+  }
+  saveState(state.activeProject, state.sessions);
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -17,7 +17,7 @@ interface BotState {
   sessions: Map<string, string>;
 }
 
-const DATA_DIR = ".data";
+const DATA_DIR = join(import.meta.dirname, "..", ".data");
 const STATE_FILE = join(DATA_DIR, "state.json");
 
 /** Load persisted state from disk. Returns null if file missing or corrupt. */


### PR DESCRIPTION
## Summary

Automated implementation for: **Persist bot state to .data/ directory for resume across restarts**

Closes #51

## Pipeline Artifacts

- Research: `.auto-pr/telegram-claude/issue-51/research.md`
- Plan: `.auto-pr/telegram-claude/issue-51/plan.md`
- Implementation Plan: `.auto-pr/telegram-claude/issue-51/plan-implementation.md`
- Review: `.auto-pr/telegram-claude/issue-51/review.md`

## Review Summary

# Review: Issue #51 — Persist bot state to .data/

**Status**: PASS

**Issues found**: None

**Confidence level**: High

**Notes**:
- All 9 `state.activeProject = ` assignments and all 6 `state.sessions.set/delete` calls properly replaced with persistence wrappers
- Atomic write pattern (write-to-tmp + rename) correctly implemented
- `loadPersistedState()` properly validates `activeProject` path exists on disk before restoring
- Lint warnings (51) are all pre-existing non-null assertion warnings, not introduced by this change
- State file uses single `state.json` (plan-consistent) rather than separate files from the initial ramblings


---
Generated by auto-pr pipeline