### PR TITLE
Plan display truncates at 4000 chars — send as multiple messages instead

### DIFF
--- a/.auto-pr/telegram-claude/issue-56/completed-summary.md
+++ b/.auto-pr/telegram-claude/issue-56/completed-summary.md
@@ -1,0 +1,13 @@
+# Completed: Fix plan display truncation (#56)
+
+## Changes
+
+1. **Added `splitText()` utility** (`src/telegram.ts`): Exported function that splits text into chunks fitting within Telegram's 4000-char limit, preferring newline boundaries (falls back to hard cut if no newline found in the last 50%).
+
+2. **Updated `presentPlan()`** (`src/bot.ts`): Replaced the truncation logic (`maxLen` + `... (truncated)`) with `splitText()` — long plans are now sent as multiple sequential messages. The inline keyboard buttons still appear after all plan chunks.
+
+## Verification
+
+- `bun run lint` passes (all warnings are pre-existing)
+- `tsc --noEmit` passes
+- No other code references the removed truncation logic

--- a/.auto-pr/telegram-claude/issue-56/plan-implementation.md
+++ b/.auto-pr/telegram-claude/issue-56/plan-implementation.md
@@ -1,0 +1,20 @@
+# Implementation Checklist: Fix plan display truncation (#56)
+
+- [x] **Task 1: Add `splitText()` utility to `telegram.ts`**
+  - Files: `src/telegram.ts`
+  - Changes: Add a new exported function `splitText(text: string, maxLen = MAX_MSG_LENGTH): string[]` after the `MAX_MSG_LENGTH` constant declaration. The function loops over the text, finds the last `\n` before `maxLen`, falls back to hard cut at `maxLen` if no newline found in the last 50%, pushes each chunk, and returns the array. Include a JSDoc comment.
+  - Acceptance: `splitText` is exported from `telegram.ts`. A string under 4000 chars returns a single-element array. A string over 4000 chars splits at `\n` boundaries. A string over 4000 chars with no newlines splits at exactly 4000.
+
+- [x] **Task 2: Replace truncation logic in `presentPlan()` with multi-message sending**
+  - Files: `src/bot.ts`
+  - Changes:
+    1. Add import: `import { splitText } from "./telegram.js";` (add to existing imports from `./telegram.js` if any, or as new import)
+    2. In `presentPlan()`, remove the truncation block (the `maxLen` constant, the ternary that appends `... (truncated)`, and the single `sendMessage` call for plan content)
+    3. Replace with: `const chunks = splitText(planContent);` then `for (const chunk of chunks) { await ctx.api.sendMessage(ctx.chat!.id, chunk); }`
+    4. Keep the existing follow-up message with `InlineKeyboard` buttons unchanged — it already sends as a separate message after the plan content
+  - Acceptance: Plans under 4000 chars display as a single message (no truncation suffix). Plans over 4000 chars display as multiple sequential messages. The inline keyboard buttons still appear after the last plan chunk. No `... (truncated)` text appears anywhere.
+
+- [x] **Task 3: Verify everything works together**
+  - Files: `src/bot.ts`, `src/telegram.ts`
+  - Changes: Run `bun run lint` to ensure no lint/format errors. Review that `splitText` import resolves correctly. Verify no other code references the removed `maxLen` / truncation logic in `presentPlan()`.
+  - Acceptance: `bun run lint` passes. The bot can be started with `bun run src/index.ts` without import errors. The `presentPlan()` function sends plan content via `splitText()` chunks followed by the button message.

--- a/.auto-pr/telegram-claude/issue-56/review.md
+++ b/.auto-pr/telegram-claude/issue-56/review.md
@@ -1,0 +1,11 @@
+# Review: Fix plan display truncation (#56)
+
+- **Status**: PASS WITH FIXES
+- **Issues found**:
+  - Missing blank line between `splitText()` function and `DRAFT_INTERVAL_MS` constant in `telegram.ts` (formatting issue, fixed)
+- **Confidence level**: high
+- **Notes**:
+  - `splitText()` correctly mirrors the existing splitting logic in `streamToTelegram` (line 283-287), including the 50% threshold for newline-based splitting
+  - The inline keyboard buttons are correctly sent as a separate message after all plan chunks
+  - No new lint warnings introduced; all 51 warnings are pre-existing
+  - The function is properly exported and imported with JSDoc

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -16,7 +16,7 @@ import {
 } from "./git";
 import { getSessionProject, listAllSessions } from "./history";
 import { loadPersistedState, setActiveProject, updateSession } from "./state";
-import { streamToTelegram } from "./telegram";
+import { splitText, streamToTelegram } from "./telegram";
 import { transcribeAudio } from "./transcribe";
 
 interface QueuedMessage {
@@ -644,13 +644,10 @@ export function createBot(
       projectPath: state.activeProject,
     };
 
-    const maxLen = 4000;
-    const display =
-      planContent.length > maxLen
-        ? `${planContent.slice(0, maxLen)}\n... (truncated)`
-        : planContent;
-
-    await ctx.api.sendMessage(ctx.chat!.id, display);
+    const chunks = splitText(planContent);
+    for (const chunk of chunks) {
+      await ctx.api.sendMessage(ctx.chat!.id, chunk);
+    }
 
     const keyboard = new InlineKeyboard()
       .text("Execute (new session)", `plan_new:${userId}`)

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -4,6 +4,25 @@ import type { ClaudeEvent } from "./claude";
 
 const MAX_MSG_LENGTH = 4000;
 const EDIT_INTERVAL_MS = 1500;
+
+/** Split text into chunks that fit within Telegram's message length limit, breaking at newline boundaries when possible */
+export function splitText(text: string, maxLen = MAX_MSG_LENGTH) {
+  if (text.length <= maxLen) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > maxLen) {
+    const cutPoint = remaining.lastIndexOf("\n", maxLen);
+    const splitAt = cutPoint > maxLen * 0.5 ? cutPoint : maxLen;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  if (remaining) {
+    chunks.push(remaining);
+  }
+  return chunks;
+}
 const DRAFT_INTERVAL_MS = 300;
 const TYPING_INTERVAL_MS = 5000;
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -23,6 +23,7 @@ export function splitText(text: string, maxLen = MAX_MSG_LENGTH) {
   }
   return chunks;
 }
+
 const DRAFT_INTERVAL_MS = 300;
 const TYPING_INTERVAL_MS = 5000;
 


### PR DESCRIPTION
## Summary

Automated implementation for: **Plan display truncates at 4000 chars — send as multiple messages instead**

Closes #56

## Pipeline Artifacts

- Research: `.auto-pr/telegram-claude/issue-56/research.md`
- Plan: `.auto-pr/telegram-claude/issue-56/plan.md`
- Implementation Plan: `.auto-pr/telegram-claude/issue-56/plan-implementation.md`
- Review: `.auto-pr/telegram-claude/issue-56/review.md`

## Review Summary

# Review: Fix plan display truncation (#56)

- **Status**: PASS WITH FIXES
- **Issues found**:
  - Missing blank line between `splitText()` function and `DRAFT_INTERVAL_MS` constant in `telegram.ts` (formatting issue, fixed)
- **Confidence level**: high
- **Notes**:
  - `splitText()` correctly mirrors the existing splitting logic in `streamToTelegram` (line 283-287), including the 50% threshold for newline-based splitting
  - The inline keyboard buttons are correctly sent as a separate message after all plan chunks
  - No new lint warnings introduced; all 51 warnings are pre-existing
  - The function is properly exported and imported with JSDoc


---
Generated by auto-pr pipeline