### PR TITLE
chore: drop ffmpeg voice-message chunking dead code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Telegram bot that bridges Claude Code CLI with Telegram. Spawns `claude` CLI as 
 - **bot.ts** — Grammy bot setup, command handlers (`/projects`, `/stop`, `/status`, `/new`), message routing. Maintains per-user state: `activeProject` path and `sessions` map (projectPath → Claude sessionId).
 - **claude.ts** — Spawns `claude -p "<prompt>" --output-format stream-json` in the active project dir. Returns `AsyncGenerator<ClaudeEvent>` yielding `text_delta` and `result` events. Tracks one active process per user via `Map<userId, AbortController>`. Resumes sessions with `-r <sessionId>`. 10-min timeout.
 - **telegram.ts** — Consumes the Claude event stream via `sendMessageDraft` (300ms interval) with fallback to progressive `editMessageText`. Auto-splits at 4000 chars. Converts Markdown → Telegram HTML (code blocks, bold, italic, links). Falls back to plain text on parse failure. Appends cost/duration/turns footer.
-- **transcribe.ts** — Voice message transcription via Groq Whisper (`whisper-large-v3-turbo`). Files >20MB chunked with ffmpeg.
+- **transcribe.ts** — Voice message transcription via Groq Whisper (`whisper-large-v3-turbo`).
 
 ### Data Flow
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Telegram bot interface for Claude Code on a VPS. Message the bot from any device
 
 - [Bun](https://bun.sh/) runtime
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI installed and authenticated
-- [ffmpeg](https://ffmpeg.org/) — required for voice messages >20MB (chunked transcription)
 - [Groq](https://console.groq.com/) API key — for voice message transcription
 
 > **Note:** This bot uses `claude -p` (programmatic usage). Starting June 15, 2026, paid Claude plans include a dedicated monthly credit for programmatic usage (`claude -p`, Agent SDK, GitHub Actions). Usage draws from this credit first, then from optional usage credits at API rates. See [Anthropic's announcement](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) for details and credit amounts by plan.
@@ -130,7 +129,7 @@ Use `/compose` to batch multiple messages into a single Claude prompt. Useful fo
 - Streams response back via `sendMessageDraft` (~300ms interval), falling back to progressive message editing if drafts aren't supported
 - Long responses auto-split into multiple messages (4000 char limit)
 - Follow-up messages continue the same Claude session via `-r <session-id>`
-- Voice notes are transcribed via Groq Whisper (`whisper-large-v3-turbo`), files >20MB are chunked with ffmpeg
+- Voice notes are transcribed via Groq Whisper (`whisper-large-v3-turbo`)
 - One active process per user; messages sent while busy are queued automatically
 - When Claude writes a plan file and calls `ExitPlanMode`, the bot intercepts it, displays the plan as plain text, and offers action buttons: execute in a new session, execute keeping context, or modify with feedback
 - Use `/stop` to cancel the current process and clear the queue

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -1,13 +1,7 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { $ } from "bun";
 import Groq from "groq-sdk";
 
 const groq = new Groq();
-const MAX_SIZE = 20 * 1024 * 1024;
 const TRANSCRIBE_TIMEOUT = 60_000;
-const FFMPEG_TIMEOUT = 30_000;
 
 /** Race a promise against a timeout, rejecting with a descriptive error */
 function withTimeout<T>(
@@ -26,51 +20,13 @@ function withTimeout<T>(
   ]);
 }
 
-/** Transcribe audio buffer using Groq Whisper, chunking if >20MB */
+/**
+ * Transcribe an audio buffer using Groq Whisper.
+ *
+ * Telegram caps bot file downloads at 20MB, so buffers always fit within
+ * Groq's request limit in a single call.
+ */
 export async function transcribeAudio(buffer: Buffer, filename: string) {
-  if (buffer.length <= MAX_SIZE) {
-    return transcribeChunk(buffer, filename);
-  }
-
-  const tempDir = await mkdtemp(join(tmpdir(), "tg-voice-"));
-
-  try {
-    const inputPath = join(tempDir, filename);
-    await Bun.write(inputPath, buffer);
-
-    const probeResult = await withTimeout(
-      $`ffprobe -v error -show_entries format=duration -of csv=p=0 ${inputPath}`.text(),
-      FFMPEG_TIMEOUT,
-      "ffprobe"
-    );
-    const totalDuration = Number.parseFloat(probeResult.trim());
-    const numChunks = Math.ceil(buffer.length / MAX_SIZE);
-    const chunkDuration = totalDuration / numChunks;
-
-    const transcriptions: string[] = [];
-
-    for (let i = 0; i < numChunks; i++) {
-      const start = i * chunkDuration;
-      const chunkPath = join(tempDir, `chunk_${i}.ogg`);
-      await withTimeout(
-        $`ffmpeg -y -i ${inputPath} -ss ${start} -t ${chunkDuration} -c copy ${chunkPath}`.quiet(),
-        FFMPEG_TIMEOUT,
-        "ffmpeg"
-      );
-
-      const chunkBuffer = Buffer.from(await Bun.file(chunkPath).arrayBuffer());
-      const text = await transcribeChunk(chunkBuffer, `chunk_${i}.ogg`);
-      transcriptions.push(text);
-    }
-
-    return transcriptions.join(" ");
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-}
-
-/** Transcribe a single audio buffer */
-async function transcribeChunk(buffer: Buffer, filename: string) {
   const file = new File([new Uint8Array(buffer)], filename, {
     type: "audio/ogg",
   });


### PR DESCRIPTION
## Summary

Removes the ffmpeg/ffprobe dependency by deleting the unreachable >20MB voice-chunking branch in `src/transcribe.ts`.

That branch was the **only** ffmpeg/ffprobe usage in the codebase. It only runs when a downloaded voice buffer exceeds 20MB — but the Telegram Bot API caps bot file downloads at 20MB (`== MAX_SIZE`), so the branch is unreachable and ffmpeg is never invoked in practice.

### Why not mediabunny?
The original idea was swapping ffmpeg for [mediabunny](https://mediabunny.dev). Investigation showed it wouldn't remove the ffmpeg dependency: the core lib is browser-only (rides WebCodecs, unavailable in Bun), and server support via `@mediabunny/server` is built on NodeAV — N-API C bindings to FFmpeg's C API. So it bundles FFmpeg as a native dep rather than eliminating it. Dropping the dead path is simpler and removes the dependency outright.

## Changes
- `src/transcribe.ts` — remove chunking branch + `transcribeChunk` helper; `transcribeAudio` now does a single Groq call. Drops `node:fs/promises`, `node:os`, `node:path`, and Bun `$` shell imports.
- `README.md` — remove ffmpeg from prerequisites and feature notes.
- `CLAUDE.md` — update transcribe.ts description.

## Verification
- `bun run typecheck` — passes
- `bunx ultracite check src/transcribe.ts` — clean (remaining repo lint warnings are pre-existing, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)