### PR TITLE
history: move session detail to message body, numbered buttons

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -851,6 +851,30 @@ export function createBot(
     await executeCancel(ctx, state);
   });
 
+  /** Format an ISO timestamp as a compact relative time (e.g. "5m ago", "Mar 3") */
+  const formatRelativeTime = (isoTimestamp: string) => {
+    const date = new Date(isoTimestamp);
+    const diffMin = Math.floor((Date.now() - date.getTime()) / 60_000);
+    if (diffMin < 1) {
+      return "just now";
+    }
+    if (diffMin < 60) {
+      return `${diffMin}m ago`;
+    }
+    const diffHour = Math.floor(diffMin / 60);
+    if (diffHour < 24) {
+      return `${diffHour}h ago`;
+    }
+    const diffDay = Math.floor(diffHour / 24);
+    if (diffDay < 7) {
+      return `${diffDay}d ago`;
+    }
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  };
+
   /** Build paginated history message with inline keyboard */
   function buildHistoryMessage(page: number, providerId: ProviderId) {
     const sessions = listAllSessions(providerId);
@@ -867,16 +891,15 @@ export function createBot(
     );
 
     const keyboard = new InlineKeyboard();
-    for (const s of pageSlice) {
-      const date = new Date(s.lastActiveAt).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
-      const label = `${date} — [${s.projectName}] ${s.summary.slice(0, 30)}`;
-      keyboard.text(label, `session:${s.sessionId}`).row();
-    }
+    const blocks = pageSlice.map((s, i) => {
+      const n = i + 1;
+      keyboard.text(String(n), `session:${s.sessionId}`);
+      const when = escapeHtml(formatRelativeTime(s.lastActiveAt));
+      const project = escapeHtml(s.projectName);
+      const topic = escapeHtml(s.summary.trim() || "(no topic)");
+      return `<b>${n}.</b> ${when} · <i>${project}</i>\n${topic}`;
+    });
+    keyboard.row();
 
     const navRow: { text: string; data: string }[] = [];
     if (safePage > 0) {
@@ -894,7 +917,8 @@ export function createBot(
 
     const pageIndicator =
       totalPages > 1 ? ` (${safePage + 1}/${totalPages})` : "";
-    return { text: `All sessions${pageIndicator}:`, keyboard };
+    const text = `<b>Sessions${pageIndicator}</b>\n\n${blocks.join("\n\n")}`;
+    return { text, keyboard };
   }
 
   bot.command("history", async (ctx) => {


### PR DESCRIPTION
**Problem:**

`/history` crams each session into an inline-button label, which Telegram truncates to roughly one line. The label packs timestamp, `[project]`, and topic into that space, so `summary` is sliced to 30 chars (`buildHistoryMessage`, `src/bot.ts`) and the topic — the one thing you scan for — is barely visible.

**Solution:**

Move the rich detail into the HTML message body, which has a 4096-char, multiline budget, and reduce the buttons to compact numbers that index the list. Each session renders as `<b>N.</b> <relative-time> · <i>project</i>` then the full topic on the next line, blocks separated by a blank line. `summary` is already capped at ~100 chars at source, so it shows in full (empty → `(no topic)`). A new `formatRelativeTime` helper renders `just now` / `Nm ago` / `Nh ago` / `Nd ago`, falling back to `MMM D` past a week. The number buttons sit on one row; the `<< Prev` / `Next >>` nav row and pagination are unchanged, and `callback_data` stays `session:<id>` so the resume handler keeps working.

---

*Security Impact:*

Session `summary`, `projectName`, and the formatted time are now interpolated into an HTML body; all three pass through the existing `escapeHtml` helper, so a `<` or `&` in a project name or prompt cannot break parsing or inject markup. No auth, secrets, or execution paths touched.

---

*Testing:*

Lint and typecheck (also run by the pre-commit hook):

```
$ bun run lint
Checked 57 files in 174ms. No fixes applied.
$ bunx tsc --noEmit
(exit 0)
```

No runtime/interactive test — verified by inspection that the numbered buttons map 1:1 to the body list and `callback_data` is byte-for-byte unchanged. Before, the topic was a 30-char slice inside a truncated button; after, the full topic is visible in the body and buttons carry only the index.