### PR TITLE
model: add /model and /effort switchers per provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ If `loginctl enable-linger` needs privilege on your host, install prints the exa
 |-----------|--------------------------------------|
 | `/projects` | Select active project directory |
 | `/provider` | Switch coding agent provider (Claude Code / Codex) |
+| `/model` | Switch model within the active provider |
+| `/effort` | Switch reasoning-effort level within the active provider |
 | `/history` | Browse and resume past sessions |
 | `/stop` | Kill running agent process |
 | `/status` | Show active project, provider & process state |

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.220",
         "@effect/platform-bun": "4.0.0-beta.78",
-        "@openai/codex-sdk": "0.139.0",
+        "@openai/codex-sdk": "0.146.0",
         "effect": "4.0.0-beta.78",
         "execa": "^9.6.1",
         "grammy": "^1.44.0",
@@ -89,21 +89,21 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
-    "@openai/codex": ["@openai/codex@0.139.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.139.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.139.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.139.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.139.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.139.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.139.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA=="],
+    "@openai/codex": ["@openai/codex@0.146.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.146.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.146.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.146.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.146.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.146.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.146.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-yG3sPWNda/2YAIQIDq9MrrjoCTIQ7rxYM5IasrG3VBcuhCLTkgeg/JzqmJq1V98RE4MJ5jCxDXXQlOjrditFRw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.139.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o+0ZKWwgDFMMLO7rwinzO0PQsgK+Vme1pMN2GeAxsX29ZgGZcyPICfpJbeGSUO1mb2a36Skjx6nfdRnxMY0r7w=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.146.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nb61yX4r5L6Z0dlC4o3u0GAK1YCd4TUvjaB382bajDoh84V+uv2hTBIVZ++fgXWV9yoeuNrNnNcn7GoTGOe2Tg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.139.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-9gkBWzu6DB2rqU4DbpxD3DE5bofGpsK46Lp0h0I+bKWc2IIcxvSi8K2utKmBLoJCbKrn4JQu7dFNGRqEfENung=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.146.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-hTQR5jy/ObfTf1MDnuJCZJAe+SljKE8DDwQWN6lDFgjsPhMQz852U2tILt8Ei+G5GkQSzemHYKl2AYPwW0Y5xw=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.139.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-tBQE5lZciRHeWZGuURgjP9S717MvTIpQMc593+DNxY2LQxozkngOkzFSQd1+/UmQKGrCqdFLu5irIwPXpSZyEw=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.146.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-qiYDxkkEFnXG7joadJW6Q+XcgyDXCpGdpa9nk/c+i0gEomur1j7bHvx12NfWWCF/y8Tqri6ay+FLuC2MjdehtA=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.139.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-14UgzDS+X4crkvdt6S02A/ZZOrS8ZyWiuTRpguCtnhNamb7unSuDxy86BWgpAl3sqiTaN2CP8VLyp2ohQ8Nbzw=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.146.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-fswvyGprAPCMiOEue/7MKMk7pCjh9kZIJfJX5i9atmfnmGYbYCcUhZsEH9LEP0+0t5xyPqDbfNXY7NSxIVuXxA=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.139.0", "", { "dependencies": { "@openai/codex": "0.139.0" } }, "sha512-r4lDckaVx4mVZy1v/7ykEhkeWjVfM/4oGJfhG0AP4+zN3Sa+jcf5hdY4EHfJasofBcp0tIF/7JCKHpv534R+tw=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.146.0", "", { "dependencies": { "@openai/codex": "0.146.0" } }, "sha512-lhlcfmufd4EvjquERH3HNG0/fuxPQJBjFsAjtP2LJjAsuyMZk245ci8xfvT4QoZ7Vnbe15y7rj/NtMNcUJIJOg=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.139.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-nlwRjsYotH1Rtqu/Q0VwQbIeO2UX1mkHK84Ov9qn/hl29QqqoBtno0tRyqIPbkXFIVQuWiAYXlV3ugLwH5fTrQ=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.146.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-EW6zdjDe+SLX2Iw+xymJ5+Pz2+DGexdstfFHXh4Ub+TfJsQPiMjGfZfNaoWgdJ2FsqSIzVKu2+G0KCMGYz2W8g=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.139.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lQrVLNz+90wdvWVNFDvCkHQRiAK9ZllmkTka3c8eqSDqdJk35Gpgppfv9Xtw5M2ZBtTq0sBdWBiCMyzGDBSpmQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.146.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-b3lxMYeR0+IhstNo4JjX1P9cPc1xwVcCVkPd1lD1wpWPJ0SBhpIkPczwbu3ZRkJcdyl342+rgyf4DUrbZLdrGA=="],
 
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.220",
     "@effect/platform-bun": "4.0.0-beta.78",
-    "@openai/codex-sdk": "0.139.0",
+    "@openai/codex-sdk": "0.146.0",
     "effect": "4.0.0-beta.78",
     "execa": "^9.6.1",
     "grammy": "^1.44.0",

--- a/src/agent/claude.ts
+++ b/src/agent/claude.ts
@@ -265,19 +265,28 @@ const buildQuery = (
   signal.addEventListener("abort", () => abortController.abort(), {
     once: true,
   });
+  // Effort overrides the boot-resolved settings for this run only; model is a
+  // plain alias/id passed straight through. "default" sentinel = no override.
+  const effort =
+    opts.effort && opts.effort !== "default"
+      ? (opts.effort as Settings["effortLevel"])
+      : undefined;
   const options: Options = {
     cwd: opts.projectDir,
     permissionMode: "bypassPermissions",
     allowDangerouslySkipPermissions: true,
     abortController,
     includePartialMessages: true,
-    settings,
+    settings: effort ? { ...settings, effortLevel: effort } : settings,
     systemPrompt: {
       type: "preset",
       preset: "claude_code",
       append: buildFileSystemPrompt(opts.chatId),
     },
   };
+  if (opts.model && opts.model !== "default") {
+    options.model = opts.model;
+  }
   if (mcpServers) {
     options.mcpServers = mcpServers;
   }
@@ -338,6 +347,20 @@ export const claudeProvider: AgentProvider = {
     cost: true,
     subagents: true,
   },
+  models: [
+    { id: "default", label: "Default" },
+    { id: "opus", label: "Opus" },
+    { id: "sonnet", label: "Sonnet" },
+    { id: "haiku", label: "Haiku" },
+    { id: "fable", label: "Fable" },
+  ],
+  effortLevels: [
+    { id: "default", label: "Default" },
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+    { id: "xhigh", label: "Extra high" },
+  ],
   run,
   listAllSessions,
   getSessionProject,

--- a/src/agent/codex.ts
+++ b/src/agent/codex.ts
@@ -4,6 +4,7 @@ import {
   Codex,
   type CodexOptions,
   type FileChangeItem,
+  type ModelReasoningEffort,
   type ThreadEvent,
   type ThreadItem,
   type ThreadOptions,
@@ -278,6 +279,11 @@ const threadOptions = (opts: RunOptions): ThreadOptions => ({
   sandboxMode: "danger-full-access",
   approvalPolicy: "never",
   skipGitRepoCheck: true,
+  // "default" sentinel = leave the Codex default in place.
+  ...(opts.model && opts.model !== "default" ? { model: opts.model } : {}),
+  ...(opts.effort && opts.effort !== "default"
+    ? { modelReasoningEffort: opts.effort as ModelReasoningEffort }
+    : {}),
 });
 
 /**
@@ -374,6 +380,20 @@ export const codexProvider: AgentProvider = {
     cost: false,
     subagents: false,
   },
+  models: [
+    { id: "default", label: "Default" },
+    { id: "gpt-5.6-sol", label: "Sol (flagship)" },
+    { id: "gpt-5.6-terra", label: "Terra (balanced)" },
+    { id: "gpt-5.6-luna", label: "Luna (fast)" },
+  ],
+  effortLevels: [
+    { id: "default", label: "Default" },
+    { id: "minimal", label: "Minimal" },
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Medium" },
+    { id: "high", label: "High" },
+    { id: "xhigh", label: "Extra high" },
+  ],
   run,
   listAllSessions,
   getSessionProject,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -72,3 +72,13 @@ export function clearSessionCache(providerId: ProviderId) {
 export function getCapabilities(providerId: ProviderId) {
   return getProvider(providerId).capabilities;
 }
+
+/** Get a provider's selectable models */
+export function getModels(providerId: ProviderId) {
+  return getProvider(providerId).models;
+}
+
+/** Get a provider's selectable reasoning-effort levels */
+export function getEffortLevels(providerId: ProviderId) {
+  return getProvider(providerId).effortLevels;
+}

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -43,10 +43,20 @@ export type EventQueue = Queue.Queue<AgentEvent, Cause.Done>;
 /** Options passed to a provider run, normalized across providers */
 export interface RunOptions {
   chatId: number;
+  /** Reasoning-effort override; `undefined` or `"default"` uses the provider default. */
+  effort?: string;
+  /** Model override; `undefined` or `"default"` uses the provider default. */
+  model?: string;
   projectDir: string;
   prompt: string;
   sessionId?: string;
   userId: number;
+}
+
+/** A selectable option (model or reasoning effort). `id` `"default"` clears any override. */
+export interface Choice {
+  id: string;
+  label: string;
 }
 
 /** Feature flags describing what a provider supports */
@@ -98,6 +108,10 @@ export type AgentProvider = ProviderSpec & {
   capabilities: ProviderCapabilities;
   clearSessionCache: () => void;
   displayName: string;
+  /** Selectable models; first entry is the `"default"` sentinel (no override). */
+  models: Choice[];
+  /** Selectable reasoning-effort levels; first entry is the `"default"` sentinel. */
+  effortLevels: Choice[];
   getSessionProject: (sessionId: string) => string | undefined;
   listAllSessions: () => SessionInfo[];
 };

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,6 +12,8 @@ import { Bot, type Context, InlineKeyboard, Keyboard } from "grammy";
 import {
   clearSessionCache,
   getCapabilities,
+  getEffortLevels,
+  getModels,
   getSessionProject,
   hasActiveProcess,
   listAllSessions,
@@ -44,6 +46,8 @@ import {
   loadPersistedState,
   setActiveProject,
   setActiveProvider,
+  setEffort,
+  setModel,
 } from "./state";
 import {
   type StreamResult,
@@ -195,6 +199,8 @@ interface UserState {
   activeProvider: ProviderId;
   composeMessages?: ComposeMessage[];
   composeStatusMessageId?: number;
+  efforts: Partial<Record<ProviderId, string>>;
+  models: Partial<Record<ProviderId, string>>;
   pendingPlan?: PendingPlan;
   queue: QueuedMessage[];
   queueStatusMessageId?: number;
@@ -280,6 +286,8 @@ const repinMessage = async (
 };
 
 const PROVIDER_CALLBACK_RE = /^provider:(.+)$/;
+const MODEL_CALLBACK_RE = /^model:(.+)$/;
+const EFFORT_CALLBACK_RE = /^effort:(.+)$/;
 const PROJECTS_PAGE_RE = /^projects:(\d+)$/;
 const PROJECT_CALLBACK_RE = /^project:(.+)$/;
 const COMPOSE_SEND_RE = /^compose_send:(\d+)$/;
@@ -340,6 +348,8 @@ function getState(id: number): UserState {
     state = {
       activeProvider: persisted?.activeProvider ?? "claude",
       activeProject: persisted?.activeProject ?? "",
+      models: persisted?.models ?? {},
+      efforts: persisted?.efforts ?? {},
       queue: [],
     };
     userStates.set(id, state);
@@ -507,6 +517,69 @@ export function createBot(
     );
   });
 
+  bot.command("model", async (ctx) => {
+    const state = getState(getUserId(ctx));
+    const provider = state.activeProvider;
+    const current = state.models[provider] ?? "default";
+    const keyboard = new InlineKeyboard();
+    for (const choice of getModels(provider)) {
+      const mark = choice.id === current ? "✓ " : "";
+      keyboard.text(`${mark}${choice.label}`, `model:${choice.id}`).row();
+    }
+    await ctx.reply(`Select a model for ${activeProviderName(state)}:`, {
+      reply_markup: keyboard,
+    });
+  });
+
+  bot.callbackQuery(MODEL_CALLBACK_RE, async (ctx) => {
+    const chosen = ctx.match?.[1] as string;
+    const state = getState(ctx.from.id);
+    const provider = state.activeProvider;
+    const choice = getModels(provider).find((m) => m.id === chosen);
+    if (!choice) {
+      await ctx.answerCallbackQuery({ text: "Unknown model" });
+      return;
+    }
+    setModel(state, provider, chosen);
+    await ctx.answerCallbackQuery({ text: `Model: ${choice.label}` });
+    await ctx.editMessageText(
+      `${activeProviderName(state)} model: ${choice.label}. Applies to your next message.`
+    );
+  });
+
+  bot.command("effort", async (ctx) => {
+    const state = getState(getUserId(ctx));
+    const provider = state.activeProvider;
+    const current = state.efforts[provider] ?? "default";
+    const keyboard = new InlineKeyboard();
+    for (const choice of getEffortLevels(provider)) {
+      const mark = choice.id === current ? "✓ " : "";
+      keyboard.text(`${mark}${choice.label}`, `effort:${choice.id}`).row();
+    }
+    await ctx.reply(
+      `Select reasoning effort for ${activeProviderName(state)}:`,
+      {
+        reply_markup: keyboard,
+      }
+    );
+  });
+
+  bot.callbackQuery(EFFORT_CALLBACK_RE, async (ctx) => {
+    const chosen = ctx.match?.[1] as string;
+    const state = getState(ctx.from.id);
+    const provider = state.activeProvider;
+    const choice = getEffortLevels(provider).find((e) => e.id === chosen);
+    if (!choice) {
+      await ctx.answerCallbackQuery({ text: "Unknown effort level" });
+      return;
+    }
+    setEffort(state, provider, chosen);
+    await ctx.answerCallbackQuery({ text: `Effort: ${choice.label}` });
+    await ctx.editMessageText(
+      `${activeProviderName(state)} reasoning effort: ${choice.label}. Applies to your next message.`
+    );
+  });
+
   /** Build paginated project selection message with inline keyboard */
   function buildProjectsMessage(page: number, projectsDir: string) {
     const projects = listProjects(projectsDir);
@@ -644,9 +717,17 @@ export function createBot(
     const composeLine = state.composeMessages
       ? `\nComposing: ${state.composeMessages.length} messages`
       : "";
+    const provider = state.activeProvider;
+    const modelId = state.models[provider] ?? "default";
+    const modelLabel =
+      getModels(provider).find((m) => m.id === modelId)?.label ?? modelId;
+    const effortId = state.efforts[provider] ?? "default";
+    const effortLabel =
+      getEffortLevels(provider).find((e) => e.id === effortId)?.label ??
+      effortId;
 
     await ctx.reply(
-      `Provider: ${activeProviderName(state)}\nProject: ${project}\nRunning: ${running}\nSessions: ${sessionCount}${branchLine}${queueLine}${composeLine}`,
+      `Provider: ${activeProviderName(state)}\nModel: ${modelLabel} · Effort: ${effortLabel}\nProject: ${project}\nRunning: ${running}\nSessions: ${sessionCount}${branchLine}${queueLine}${composeLine}`,
       { reply_markup: mainKeyboard }
     );
   });
@@ -657,6 +738,8 @@ export function createBot(
         "<b>Commands:</b>",
         "/projects — switch active project",
         "/provider — switch coding agent provider",
+        "/model — switch model for the active provider",
+        "/effort — switch reasoning effort for the active provider",
         "/history — resume a past session",
         "/new — start fresh conversation",
         "/stop — kill active process",
@@ -1245,6 +1328,8 @@ export function createBot(
         projectDir: project,
         chatId: requireChat(ctx),
         sessionId,
+        model: state.models[provider],
+        effort: state.efforts[provider],
       });
       const result = await streamToTelegram(
         ctx,

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ bot.start({
     const commands = [
       { command: "projects", description: "Switch active project" },
       { command: "provider", description: "Switch coding agent provider" },
+      { command: "model", description: "Switch model for active provider" },
+      { command: "effort", description: "Switch reasoning effort" },
       { command: "history", description: "Resume a past session" },
       { command: "new", description: "Start fresh conversation" },
       { command: "stop", description: "Kill active process" },

--- a/src/state.test.ts
+++ b/src/state.test.ts
@@ -70,6 +70,39 @@ describe("readStateFile", () => {
     }
   });
 
+  test("model/effort choices round-trip, ignoring non-string entries", () => {
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        activeProvider: "claude",
+        activeProject: dir,
+        models: { claude: "opus", codex: 42 },
+        efforts: { codex: "high" },
+      })
+    );
+    const loaded = readStateFile(statePath);
+    expect(loaded.status).toBe("ok");
+    if (loaded.status === "ok") {
+      expect(loaded.models.claude).toBe("opus");
+      expect(loaded.models.codex).toBeUndefined(); // non-string dropped
+      expect(loaded.efforts.codex).toBe("high");
+      expect(loaded.efforts.claude).toBeUndefined();
+    }
+  });
+
+  test("a state file without models/efforts loads them as empty maps", () => {
+    writeFileSync(
+      statePath,
+      JSON.stringify({ activeProvider: "claude", activeProject: dir })
+    );
+    const loaded = readStateFile(statePath);
+    expect(loaded.status).toBe("ok");
+    if (loaded.status === "ok") {
+      expect(loaded.models).toEqual({});
+      expect(loaded.efforts).toEqual({});
+    }
+  });
+
   test("a real IO fault (not ENOENT) is rethrown, never masked as empty", () => {
     // Reading a directory as a file surfaces EISDIR — a genuine fault the loader
     // must surface rather than silently treat as missing/corrupt state.

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,15 +11,22 @@ import { runtime } from "./runtime";
 
 const STATE_VERSION = 1 as const;
 
+/** Per-provider selection map (model id or effort id, keyed by provider). */
+type ProviderChoices = Partial<Record<ProviderId, string>>;
+
 interface PersistedState {
   activeProject: string;
   activeProvider: ProviderId;
+  efforts?: ProviderChoices;
+  models?: ProviderChoices;
   version?: number;
 }
 
 interface BotState {
   activeProject: string;
   activeProvider: ProviderId;
+  efforts: ProviderChoices;
+  models: ProviderChoices;
 }
 
 const DATA_DIR = join(import.meta.dirname, "..", ".data");
@@ -98,11 +105,33 @@ function parseState(text: string) {
       ? activeProviderRaw
       : DEFAULT_PROVIDER;
 
+  const record =
+    parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : {};
+
   return {
     activeProvider,
     activeProject,
+    models: coerceChoices(record.models),
+    efforts: coerceChoices(record.efforts),
     legacySessions: buildLegacySessions(parsed),
   };
+}
+
+/** Keep only string-valued `claude`/`codex` keys from an untrusted choices map. */
+function coerceChoices(raw: unknown): ProviderChoices {
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+  const out: ProviderChoices = {};
+  for (const id of ["claude", "codex"] as const) {
+    const value = (raw as Record<string, unknown>)[id];
+    if (typeof value === "string") {
+      out[id] = value;
+    }
+  }
+  return out;
 }
 
 /** Discriminated result of reading the raw state file (no side effects beyond corrupt-preservation). */
@@ -184,16 +213,20 @@ export function loadPersistedState() {
   return {
     activeProvider: loaded.activeProvider,
     activeProject: loaded.activeProject,
+    models: loaded.models,
+    efforts: loaded.efforts,
   };
 }
 
-/** Persist active project + provider via a versioned, collision-safe atomic write. */
-function saveState(activeProvider: ProviderId, activeProject: string) {
+/** Persist active project, provider, and per-provider model/effort choices atomically. */
+function saveState(state: BotState) {
   mkdirSync(DATA_DIR, { recursive: true });
   const data: PersistedState = {
     version: STATE_VERSION,
-    activeProvider,
-    activeProject,
+    activeProvider: state.activeProvider,
+    activeProject: state.activeProject,
+    models: state.models,
+    efforts: state.efforts,
   };
   const { bytes, durationMs } = writeJsonAtomic(STATE_FILE, data);
   logEvent({ event: "state.save", bytes, durationMs });
@@ -202,11 +235,27 @@ function saveState(activeProvider: ProviderId, activeProject: string) {
 /** Set active project and persist. */
 export function setActiveProject(state: BotState, path: string) {
   state.activeProject = path;
-  saveState(state.activeProvider, state.activeProject);
+  saveState(state);
 }
 
 /** Set the active provider and persist. */
 export function setActiveProvider(state: BotState, providerId: ProviderId) {
   state.activeProvider = providerId;
-  saveState(state.activeProvider, state.activeProject);
+  saveState(state);
+}
+
+/** Set the model for a provider and persist. */
+export function setModel(state: BotState, provider: ProviderId, model: string) {
+  state.models[provider] = model;
+  saveState(state);
+}
+
+/** Set the reasoning-effort level for a provider and persist. */
+export function setEffort(
+  state: BotState,
+  provider: ProviderId,
+  effort: string
+) {
+  state.efforts[provider] = effort;
+  saveState(state);
 }


### PR DESCRIPTION
**Problem:**

The bot lets you switch providers with `/provider`, but never the model or reasoning effort within a provider — every run used each provider's default. There was no model plumbing at all: `RunOptions` had no `model` field and neither provider passed one.

**Solution:**

Add `/model` and `/effort` commands that mirror `/provider`: an inline keyboard of the active provider's choices, `✓` on the current one, persisted per-provider in `state.json` and applied to the next message. Each provider owns its own catalog on `AgentProvider` (`models`, `effortLevels`), so the buttons and value ladders stay provider-specific.

- **Claude** — `options.model` alias (`default`/`opus`/`sonnet`/`haiku`/`fable`); effort via `Settings.effortLevel` (`low`→`xhigh`), overriding the boot settings for that run only.
- **Codex** — `ThreadOptions.model` (`gpt-5.6-sol`/`terra`/`luna`); effort via `modelReasoningEffort` (`minimal`→`xhigh`). Requires the codex-sdk bump below — the old `0.139.0` binary didn't know the `5.6` slugs.

`@openai/codex-sdk` `0.139.0` → `0.146.0` (bundled CLI `0.146.0`) so the new Codex models resolve. A `"default"` sentinel in each catalog clears the override. State persistence is back-compatible: a `state.json` without `models`/`efforts` loads them as empty maps.

**Testing:**

```
$ bun test
 75 pass  0 fail   (before)
 77 pass  0 fail   (after — 2 new state tests: choice round-trip + back-compat)

$ bun run typecheck   # clean
$ bunx --bun ultracite check   # clean
```

Verified model/effort field types against the installed `.d.ts` of both SDKs (`options.model`/`Settings.effortLevel`; `ThreadOptions.model`/`ModelReasoningEffort`). Codex `gpt-5.6-sol/terra/luna` confirmed present in the updated `0.146.0` native binary. Not exercised end-to-end against a live run — will restart the bot on this branch to test interactively before merge.