### PR TITLE
claude: stream input so background workflows report back

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Telegram bot interface for coding agents (Claude Code + OpenAI Codex) on a VPS. Message the bot from any device, it runs the active agent in your project directories and streams back results. Switch providers at runtime with `/provider`.
 
+![telegram-claude demo](https://lxbpjvrr41.ufs.sh/f/6KZjuRTQYJxHIndwqxeD4mh8cu39QUEVvM0jCpqogftBHWKs)
+
 ## Features
 
 - **Multi-provider** — switch between Claude Code and OpenAI Codex at runtime via `/provider`; sessions and capabilities are tracked per provider

--- a/src/agent/claude-input.ts
+++ b/src/agent/claude-input.ts
@@ -1,0 +1,23 @@
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { RunOptions } from "./types";
+
+/**
+ * The query input as an AsyncIterable rather than a string. This is the crux of
+ * background-task support: a string prompt puts the CLI in single-turn mode,
+ * which force-closes stdin on the first `result` — ending the session before a
+ * background task (dynamic workflow, backgrounded subagent) can report back. An
+ * async iterable keeps the session live; the CLI re-drives the agent when the
+ * task settles. The stream yields the user turn, then stays open until `closed`
+ * resolves (a turn ended with no background tasks left, or the run was aborted).
+ */
+export async function* userTurns(
+  opts: RunOptions,
+  closed: Promise<void>
+): AsyncGenerator<SDKUserMessage> {
+  yield {
+    type: "user",
+    parent_tool_use_id: null,
+    message: { role: "user", content: opts.prompt },
+  };
+  await closed;
+}

--- a/src/agent/claude.test.ts
+++ b/src/agent/claude.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { userTurns } from "./claude-input";
+import type { RunOptions } from "./types";
+
+const opts = (prompt: string) =>
+  ({ prompt, chatId: 1, projectDir: "/tmp", userId: 1 }) as RunOptions;
+
+test("userTurns yields the initial user turn as a streaming SDKUserMessage", async () => {
+  const gen = userTurns(opts("hello"), new Promise<void>(() => undefined));
+  const first = await gen.next();
+  expect(first.done).toBe(false);
+  expect(first.value).toEqual({
+    type: "user",
+    parent_tool_use_id: null,
+    message: { role: "user", content: "hello" },
+  });
+});
+
+test("userTurns stays open until `closed` resolves, then ends", async () => {
+  let close: () => void = () => undefined;
+  const closed = new Promise<void>((resolve) => {
+    close = resolve;
+  });
+  const gen = userTurns(opts("hi"), closed);
+  await gen.next(); // consume the initial turn
+
+  let settled = false;
+  const pending = gen.next().then((r) => {
+    settled = true;
+    return r;
+  });
+  // Give the microtask queue a chance; the stream must still be open.
+  await Promise.resolve();
+  expect(settled).toBe(false);
+
+  close();
+  const done = await pending;
+  expect(done.done).toBe(true);
+});

--- a/src/agent/claude.ts
+++ b/src/agent/claude.ts
@@ -12,6 +12,7 @@ import {
   getSessionProject,
   listAllSessions,
 } from "./claude-history";
+import { userTurns } from "./claude-input";
 import { readExecutorMcpServers } from "./executor-mcp";
 import type { AgentEvent, AgentProvider, RunOptions } from "./types";
 
@@ -255,12 +256,12 @@ const buildFileSystemPrompt = (chatId: number) => {
  * ambient ~/.claude/settings.json. `mcpServers` carries the Executor MCP server
  * when configured (undefined otherwise, so the key is simply omitted).
  */
-const buildQuery = (
+const buildOptions = (
   opts: RunOptions,
   signal: AbortSignal,
   settings: Settings,
   mcpServers: Options["mcpServers"]
-) => {
+): Options => {
   const abortController = new AbortController();
   signal.addEventListener("abort", () => abortController.abort(), {
     once: true,
@@ -293,7 +294,7 @@ const buildQuery = (
   if (opts.sessionId) {
     options.resume = opts.sessionId;
   }
-  return { prompt: opts.prompt, options };
+  return options;
 };
 
 /** Boot-resolved per-run inputs (hardening settings + Executor MCP wiring). */
@@ -307,6 +308,14 @@ const readRunConfig = Effect.all({
  * AgentEvents. Text/thinking are sourced from streamed partial messages;
  * tool_use and plan_ready from the complete assistant messages; subagent
  * lifecycle from task_started/task_notification system messages.
+ *
+ * Runs in streaming-input mode so background tasks (dynamic workflows,
+ * backgrounded subagents) can report completion back to the same agent, which
+ * then continues acting on the result. The session is held open across turns
+ * and closed only when a turn ends with no live background tasks remaining
+ * (tracked via `background_tasks_changed`, which carries the full live set), or
+ * on abort. A run with no background tasks behaves exactly as before: one turn,
+ * one result, immediate close.
  */
 async function* run(
   opts: RunOptions,
@@ -319,10 +328,18 @@ async function* run(
   };
   let sawStreamEvents = false;
 
+  const liveTasks = new Set<string>();
+  let closeInput: () => void = () => {
+    // replaced by the promise executor below
+  };
+  const closed = new Promise<void>((resolve) => {
+    closeInput = resolve;
+  });
+  signal.addEventListener("abort", () => closeInput(), { once: true });
+
   const { settings, mcpServers } = runtime.runSync(readRunConfig);
-  for await (const msg of query(
-    buildQuery(opts, signal, settings, mcpServers)
-  )) {
+  const options = buildOptions(opts, signal, settings, mcpServers);
+  for await (const msg of query({ prompt: userTurns(opts, closed), options })) {
     if (msg.type === "stream_event") {
       sawStreamEvents = true;
       yield* handlePartialEvent(state, msg.event);
@@ -330,7 +347,18 @@ async function* run(
       yield* handleAssistantBlocks(state, msg.message.content, sawStreamEvents);
     } else if (msg.type === "result") {
       yield* handleResultMessage(msg);
+      // Turn ended: end the session only when no background work is pending,
+      // else stay open so the task's completion re-drives the agent.
+      if (liveTasks.size === 0) {
+        closeInput();
+      }
     } else if (msg.type === "system") {
+      if (msg.subtype === "background_tasks_changed") {
+        liveTasks.clear();
+        for (const task of msg.tasks) {
+          liveTasks.add(task.task_id);
+        }
+      }
       yield* handleSystemMessage(msg);
     }
   }


### PR DESCRIPTION
**Problem:**

When the agent launches a dynamic workflow (or any backgrounded sub-agent), the workflow runs to completion but the main agent never receives the result and goes silent — surfaced as "no completion record was found in background workflow". It works in the Claude CLI but hangs through this bot.

`claude.ts` drives `query()` with a plain **string** prompt. In the SDK that sets `isSingleUserTurn=true`, and the CLI force-closes stdin on the **first** `type:'result'` (verified in the bundled `sdk.mjs`). That ends the session before a background task can report back. The control plane that delivers a `task_notification` back into a live turn is streaming-input-only (`sdk.d.ts:2282`: "control requests … only supported when streaming input/output is used").

**Solution:**

Drive `query()` in streaming-input mode: pass an `AsyncIterable<SDKUserMessage>` (`claude-input.ts` `userTurns`) instead of a string. That sets `isSingleUserTurn=false`, so `result` no longer closes stdin and the CLI re-drives the agent when the task settles — the agent then acts on it (opens a PR, restarts a failed sub-agent). The session is held open across turns and closed only when a turn ends with **no live background tasks**, tracked via `background_tasks_changed` (a level signal carrying the full live set). A run with no background tasks is unchanged: one turn, one result, immediate close.

`userTurns` lives in its own module to dodge the `claude.ts → runtime → bot → registry → claude` import cycle (importing `claude.ts` first throws `Cannot access 'claudeProvider' before initialization`).

**Testing:**

```
$ bun test                 # 79 pass / 0 fail (2 new: userTurns contract)
$ bun run typecheck        # clean
$ bunx --bun ultracite check  # clean
```

Live smoke (temp script, since `run()` can't be unit-tested against the real subprocess) — drove `run()` end-to-end through the SDK with a trivial prompt:
```
PASS: run() terminated in 10794ms, sawResult=true
event kinds: session_init, text_delta, result
```
This proves the critical regression is safe: the normal no-workflow path still closes on the first result and does not hang. The background-workflow round-trip itself needs a real multi-agent run — will validate live on this branch before merge.

**Note:** a run now stays alive for the whole workflow rather than orphaning it after the first result. If a workflow genuinely hangs, the run stays open until `/stop` (or `RUN_TIMEOUT_MS`, currently unset).